### PR TITLE
Add CastOptions for subtitles and custom casting parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the UPnPCast library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Fixed
+- **Device discovery failures (#1)**: set `SO_REUSEADDR` before binding SSDP port 1900 (previously set after binding, which was ineffective) with an ephemeral-port fallback; run the SSDP response listener on a dedicated daemon thread started before M-SEARCH sends so no response is lost; read timeouts no longer terminate the listener loop
+- **Multicast reception**: acquire a `WifiManager.MulticastLock` during `init()` so the Wi-Fi stack does not filter SSDP multicast traffic
+- **Re-initialization**: `cleanup()` → `init()` cycles now work — coroutine scopes are recreated and the cache manager rebinds to the current scope
+- **Control URL**: default port to 80 when the device location URL has no explicit port (was producing `http://host:-1/...`)
+
+### ✨ Added
+- **`CastOptions` (#2)**: customize casting with `subtitleUri` (external subtitles, incl. Samsung `sec:SubtitleUri`), `subtitleMimeType`, `mimeType` and `upnpClass` overrides, or a full DIDL-Lite `metadata` override — available on `cast()`, `castToDevice()` and `castLocalFile()`
+
+### 🔧 Changed
+- `DeviceDescriptionParser` is now `internal` (was accidentally public)
+- Removed unused `okhttp`/`gson` dependencies
+- Removed phantom `VideoSelectorActivity` declaration from the library manifest
+
 ## [1.1.0] - 2025-06-03
 
 ### 🚀 Major Architecture Refactoring

--- a/README.md
+++ b/README.md
@@ -275,6 +275,36 @@ lifecycleScope.launch {
 }
 ```
 
+### Custom Casting Options (Subtitles & Metadata)
+
+Customize how media is presented to the target device with `CastOptions` — attach a subtitle, override the MIME type, or supply the full DIDL-Lite metadata:
+
+```kotlin
+// Attach an external subtitle (URL must be reachable by the TV)
+val options = CastOptions(
+    subtitleUri = "http://192.168.1.100:8080/movie.srt"
+)
+val success = DLNACast.castToDevice(device, url, title, options)
+
+// Full control for advanced users: provide the DIDL-Lite metadata verbatim
+val custom = CastOptions(
+    metadata = """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+      <item id="1" parentID="0" restricted="1">
+        <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">My Title</dc:title>
+      </item>
+    </DIDL-Lite>"""
+)
+DLNACast.cast(url, title, custom)
+```
+
+| Field | Description |
+|---|---|
+| `metadata` | Full DIDL-Lite override, sent verbatim (other fields ignored) |
+| `subtitleUri` | HTTP(S) subtitle URL attached to the cast |
+| `subtitleMimeType` | Subtitle MIME type, defaults to `text/srt` |
+| `mimeType` | Overrides the auto-detected media MIME type |
+| `upnpClass` | Overrides the UPnP object class |
+
 ### Local File Casting
 ```kotlin
 lifecycleScope.launch {

--- a/README_zh.md
+++ b/README_zh.md
@@ -263,6 +263,36 @@ lifecycleScope.launch {
 }
 ```
 
+### 自定义投屏参数（字幕与元数据）
+
+通过 `CastOptions` 自定义投屏时传给设备的参数——附带字幕、覆盖 MIME 类型，或直接提供完整 DIDL-Lite 元数据：
+
+```kotlin
+// 附加外挂字幕（URL 需电视可访问）
+val options = CastOptions(
+    subtitleUri = "http://192.168.1.100:8080/movie.srt"
+)
+val success = DLNACast.castToDevice(device, url, title, options)
+
+// 高级用户：原样发送自定义 DIDL-Lite 元数据
+val custom = CastOptions(
+    metadata = """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+      <item id="1" parentID="0" restricted="1">
+        <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">我的标题</dc:title>
+      </item>
+    </DIDL-Lite>"""
+)
+DLNACast.cast(url, title, custom)
+```
+
+| 字段 | 说明 |
+|---|---|
+| `metadata` | 完整 DIDL-Lite 覆盖，原样发送（设置后忽略其他字段） |
+| `subtitleUri` | 附加到投屏的字幕 HTTP(S) 地址 |
+| `subtitleMimeType` | 字幕 MIME 类型，默认 `text/srt` |
+| `mimeType` | 覆盖自动识别的媒体 MIME 类型 |
+| `upnpClass` | 覆盖 UPnP 对象类别 |
+
 ### 本地文件投屏
 ```kotlin
 lifecycleScope.launch {

--- a/app/src/main/java/com/yinnho/upnpcast/CastOptions.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/CastOptions.kt
@@ -1,0 +1,26 @@
+package com.yinnho.upnpcast
+
+/**
+ * Advanced casting options for customizing how media is presented to the
+ * target device.
+ *
+ * All fields are optional; when unset the library keeps its previous
+ * behavior (auto-detected metadata).
+ *
+ * @param metadata Full DIDL-Lite metadata override. When set, it is sent
+ * verbatim as `CurrentURIMetaData` and every other field is ignored.
+ * @param subtitleUri HTTP(S) URL of a subtitle file to attach to the cast.
+ * @param subtitleMimeType MIME type of [subtitleUri]; defaults to
+ * `text/srt`.
+ * @param mimeType Overrides the auto-detected media MIME type (e.g.
+ * `video/mp4`) used in the `res` protocolInfo.
+ * @param upnpClass Overrides the UPnP object class (e.g.
+ * `object.item.videoItem`).
+ */
+data class CastOptions(
+    val metadata: String? = null,
+    val subtitleUri: String? = null,
+    val subtitleMimeType: String = "text/srt",
+    val mimeType: String? = null,
+    val upnpClass: String? = null
+)

--- a/app/src/main/java/com/yinnho/upnpcast/DLNACast.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/DLNACast.kt
@@ -125,14 +125,19 @@ object DLNACast {
     /**
      * Cast media to best available device
      */
-    suspend fun cast(url: String, title: String? = null): Boolean = 
-        suspendOnce { callback -> CoreManager.cast(url, title, callback) }
-    
+    suspend fun cast(url: String, title: String? = null, options: CastOptions = CastOptions()): Boolean =
+        suspendOnce { callback -> CoreManager.cast(url, title, options, callback) }
+
     /**
      * Cast media to specific device
      */
-    suspend fun castToDevice(device: Device, url: String, title: String? = null): Boolean = 
-        suspendOnce { callback -> CoreManager.castToDevice(device, url, title, callback) }
+    suspend fun castToDevice(
+        device: Device,
+        url: String,
+        title: String? = null,
+        options: CastOptions = CastOptions()
+    ): Boolean =
+        suspendOnce { callback -> CoreManager.castToDevice(device, url, title, options, callback) }
     
     /**
      * Get current playback progress
@@ -155,10 +160,15 @@ object DLNACast {
     /**
      * Cast local file to device
      */
-    suspend fun castLocalFile(filePath: String, device: Device, title: String? = null) {
+    suspend fun castLocalFile(
+        filePath: String,
+        device: Device,
+        title: String? = null,
+        options: CastOptions = CastOptions()
+    ) {
         suspendCancellableCoroutine<Unit> { cont ->
             var resumed = false
-            CoreManager.castLocalFileToDevice(filePath, device, title) { success, message ->
+            CoreManager.castLocalFileToDevice(filePath, device, title, options) { success, message ->
                 if (!resumed) {
                     resumed = true
                     if (success) {

--- a/app/src/main/java/com/yinnho/upnpcast/internal/core/CoreManager.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/core/CoreManager.kt
@@ -3,6 +3,7 @@ package com.yinnho.upnpcast.internal.core
 import android.content.Context
 import android.net.wifi.WifiManager
 import android.util.Log
+import com.yinnho.upnpcast.CastOptions
 import com.yinnho.upnpcast.DLNACast.Device
 
 import com.yinnho.upnpcast.DLNACast.PlaybackState
@@ -125,18 +126,18 @@ internal class CoreManager {
         /**
          * Cast media to available device (auto-select best device)
          */
-        fun cast(url: String, title: String?, callback: (Boolean) -> Unit) {
+        fun cast(url: String, title: String?, options: CastOptions, callback: (Boolean) -> Unit) {
             ensureInitialized {
                 val availableDevices = getAllDevices()
                 if (availableDevices.isNotEmpty()) {
                     val bestDevice = selectBestDevice(availableDevices)
-                    connectAndPlay(bestDevice, url, title ?: "Media", callback)
+                    connectAndPlay(bestDevice, url, title ?: "Media", options, callback)
                 } else {
                     Log.i(TAG, "No devices available, searching first...")
                     search(3000) { devices ->
                         if (devices.isNotEmpty()) {
                             val bestDevice = selectBestDevice(devices)
-                            connectAndPlay(bestDevice, url, title ?: "Media", callback)
+                            connectAndPlay(bestDevice, url, title ?: "Media", options, callback)
                         } else {
                             Log.w(TAG, "No devices found after search")
                             callback(false)
@@ -145,20 +146,32 @@ internal class CoreManager {
                 }
             }
         }
-        
+
         /**
          * Cast media to specific device
          */
-        fun castToDevice(device: Device, url: String, title: String?, callback: (Boolean) -> Unit) {
+        fun castToDevice(
+            device: Device,
+            url: String,
+            title: String?,
+            options: CastOptions,
+            callback: (Boolean) -> Unit
+        ) {
             ensureInitialized {
-                connectAndPlay(device, url, title ?: "Media", callback)
+                connectAndPlay(device, url, title ?: "Media", options, callback)
             }
         }
-        
+
         /**
          * Connect to device and start media playback
          */
-        fun connectAndPlay(device: Device, url: String, title: String, callback: (success: Boolean) -> Unit) {
+        fun connectAndPlay(
+            device: Device,
+            url: String,
+            title: String,
+            options: CastOptions,
+            callback: (success: Boolean) -> Unit
+        ) {
             try {
                 val remoteDevice = devices[device.id] ?: throw IllegalArgumentException("Device not found: ${device.id}")
                 val services = remoteDevice.details["services"] as? List<*>
@@ -167,7 +180,7 @@ internal class CoreManager {
                     ScopeManager.appScope.launch {
                         try {
                             val controller = DlnaMediaController.getController(remoteDevice)
-                            val success = controller.playMediaDirect(url, title)
+                            val success = controller.playMediaDirect(url, title, options = options)
                             withContext(Dispatchers.Main) {
                                 callback(success)
                             }
@@ -282,22 +295,28 @@ internal class CoreManager {
         /**
          * Cast local file to specified device
          */
-        fun castLocalFileToDevice(filePath: String, device: Device, title: String?, callback: (success: Boolean, message: String) -> Unit) {
+        fun castLocalFileToDevice(
+            filePath: String,
+            device: Device,
+            title: String?,
+            options: CastOptions,
+            callback: (success: Boolean, message: String) -> Unit
+        ) {
             ensureInitialized {
                 val context = contextRef?.get()
                 if (context == null) {
                     callback(false, "Context has been released, please reinitialize")
                     return@ensureInitialized
                 }
-                
+
                 val remoteDevice = devices[device.id]
                 if (remoteDevice == null) {
                     callback(false, "Device not found: ${device.id}")
                     return@ensureInitialized
                 }
-                
+
                 currentDevice = remoteDevice
-                LocalCastManager.castLocalFile(context, filePath, remoteDevice, title, ScopeManager.appScope, callback)
+                LocalCastManager.castLocalFile(context, filePath, remoteDevice, title, options, ScopeManager.appScope, callback)
             }
         }
         

--- a/app/src/main/java/com/yinnho/upnpcast/internal/discovery/DeviceDescriptionParser.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/discovery/DeviceDescriptionParser.kt
@@ -11,7 +11,7 @@ import java.net.URL
 /**
  * UPnP device description parser
  */
-class DeviceDescriptionParser {
+internal class DeviceDescriptionParser {
     companion object {
         private const val TAG = "DeviceDescriptionParser"
         private const val CONNECT_TIMEOUT = 5000

--- a/app/src/main/java/com/yinnho/upnpcast/internal/localcast/LocalCastManager.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/localcast/LocalCastManager.kt
@@ -2,6 +2,7 @@ package com.yinnho.upnpcast.internal.localcast
 
 import android.content.Context
 import android.util.Log
+import com.yinnho.upnpcast.CastOptions
 import com.yinnho.upnpcast.internal.discovery.RemoteDevice
 import com.yinnho.upnpcast.internal.media.DlnaMediaController
 import kotlinx.coroutines.*
@@ -20,9 +21,10 @@ internal class LocalCastManager {
          */
         fun castLocalFile(
             context: Context,
-            filePath: String, 
-            device: RemoteDevice, 
-            title: String?, 
+            filePath: String,
+            device: RemoteDevice,
+            title: String?,
+            options: CastOptions,
             scope: CoroutineScope,
             callback: (success: Boolean, message: String) -> Unit
         ) {
@@ -68,7 +70,7 @@ internal class LocalCastManager {
                     
                     try {
                         val controller = DlnaMediaController.getController(device)
-                        val success = controller.playMediaDirect(fileUrl, mediaTitle)
+                        val success = controller.playMediaDirect(fileUrl, mediaTitle, options = options)
                         withContext(Dispatchers.Main) {
                             if (success) {
                                 callback(true, "Local file casting successful")

--- a/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
@@ -10,6 +10,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 import java.util.Locale
+import com.yinnho.upnpcast.CastOptions
 import com.yinnho.upnpcast.internal.discovery.RemoteDevice
 import com.yinnho.upnpcast.internal.discovery.DeviceDescriptionParser
 
@@ -124,15 +125,16 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
      * Play media with direct URL and metadata
      */
     suspend fun playMediaDirect(
-        mediaUrl: String, 
-        title: String, 
-        episodeLabel: String = "", 
-        positionMs: Long = 0
+        mediaUrl: String,
+        title: String,
+        episodeLabel: String = "",
+        positionMs: Long = 0,
+        options: CastOptions = CastOptions()
     ): Boolean = withContext(Dispatchers.IO) {
         if (!checkAvailable()) return@withContext false
-        
+
         try {
-            val setUriSuccess = setMediaUri(mediaUrl, createMetadata(title, episodeLabel, mediaUrl))
+            val setUriSuccess = setMediaUri(mediaUrl, createMetadata(title, episodeLabel, mediaUrl, options))
             if (!setUriSuccess) return@withContext false
             
             val playSuccess = control("play")
@@ -469,32 +471,53 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
     private fun escapeXmlUrl(url: String): String = escapeXmlBasic(url)
     
     /**
-     * Create DIDL-Lite metadata - simplified version
+     * Create DIDL-Lite metadata
+     *
+     * [CastOptions.metadata] is sent verbatim when provided. Otherwise the
+     * metadata is generated, honoring the mimeType/upnpClass overrides and
+     * attaching the subtitle resource when [CastOptions.subtitleUri] is set
+     * (the Samsung `sec:SubtitleUri` extension is included as well).
      */
-    private fun createMetadata(title: String, episodeLabel: String, mediaUrl: String = ""): String {
+    private fun createMetadata(
+        title: String,
+        episodeLabel: String,
+        mediaUrl: String = "",
+        options: CastOptions = CastOptions()
+    ): String {
+        options.metadata?.let { return it }
+
         val displayTitle = if (episodeLabel.isNotEmpty()) "$title - $episodeLabel" else title
         val safeDisplayTitle = escapeXmlContent(displayTitle)
         val safeMediaUrl = escapeXmlUrl(mediaUrl)
-        
-        val mediaType = when {
+
+        val mediaType = options.mimeType ?: when {
             mediaUrl.contains(".mp4", ignoreCase = true) -> "video/mp4"
             mediaUrl.contains(".mkv", ignoreCase = true) -> "video/x-matroska"
             mediaUrl.contains(".m3u8", ignoreCase = true) -> "application/vnd.apple.mpegurl"
             mediaUrl.contains(".mp3", ignoreCase = true) -> "audio/mpeg"
             else -> "video/mp4"
         }
-        
-        val upnpClass = if (mediaType.startsWith("video") || mediaType.contains("mpegurl")) {
+
+        val upnpClass = options.upnpClass ?: if (mediaType.startsWith("video") || mediaType.contains("mpegurl")) {
             "object.item.videoItem"
         } else {
             "object.item.audioItem.musicTrack"
         }
-        
-        return """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
+
+        val safeSubtitleUri = options.subtitleUri?.let { escapeXmlUrl(it) }
+        val subtitleRes = safeSubtitleUri
+            ?.let { "\n        <res protocolInfo=\"http-get:*:${options.subtitleMimeType}:*\">$it</res>" }
+            ?: ""
+        val subtitleElement = safeSubtitleUri
+            ?.let { "\n        <sec:SubtitleUri>$it</sec:SubtitleUri>" }
+            ?: ""
+        val secNamespace = if (safeSubtitleUri != null) " xmlns:sec=\"http://www.samsung.com/sec/\"" else ""
+
+        return """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"$secNamespace>
     <item id="1" parentID="0" restricted="1">
         <dc:title>$safeDisplayTitle</dc:title>
-        <upnp:class>$upnpClass</upnp:class>
-        <res protocolInfo="http-get:*:$mediaType:*">$safeMediaUrl</res>
+        <upnp:class>$upnpClass</upnp:class>$subtitleElement
+        <res protocolInfo="http-get:*:$mediaType:*">$safeMediaUrl</res>$subtitleRes
     </item>
 </DIDL-Lite>"""
     }


### PR DESCRIPTION
## Summary
- Add public `CastOptions` type: `metadata` (verbatim DIDL-Lite override), `subtitleUri` (external subtitles, emitted as a standard subtitle `<res>` plus the Samsung `sec:SubtitleUri` extension), `subtitleMimeType`, `mimeType`, and `upnpClass` overrides
- Accepted as an optional parameter on `cast()`, `castToDevice()` and `castLocalFile()` — fully source-compatible for existing callers
- `DeviceDescriptionParser` is now `internal` (was accidentally public, part of the visibility complaint in #2)
- Documented the new API in README.md / README_zh.md and added an `[Unreleased]` section to CHANGELOG.md (also covers the discovery fixes from 1f702f8)

Closes #2

## Test plan
- [x] `./gradlew test lint assembleRelease` green locally (Java 21 / AGP 8.9.2)
- [x] Demo app compiles unchanged (default arguments keep all existing call sites source-compatible)
- [ ] Manual: cast with `subtitleUri` against a Samsung TV (expects `sec:SubtitleUri` support) and a generic renderer (expects subtitle `<res>`) — needs real devices