### PR TITLE
Return full search results and real playback state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+- **Live playback state**: `DLNACast.getPlaybackState()` queries the device via GetTransportInfo, so remote pauses/stops are reflected; `getState()` now reports the last observed transport state instead of always `PLAYING` while connected
+- **`CastOptions` (#2)**: customize casting with `subtitleUri` (external subtitles, incl. Samsung `sec:SubtitleUri`), `subtitleMimeType`, `mimeType` and `upnpClass` overrides, or a full DIDL-Lite `metadata` override — available on `cast()`, `castToDevice()` and `castLocalFile()`
+
 ### 🐛 Fixed
 - **Device discovery failures (#1)**: set `SO_REUSEADDR` before binding SSDP port 1900 (previously set after binding, which was ineffective) with an ephemeral-port fallback; run the SSDP response listener on a dedicated daemon thread started before M-SEARCH sends so no response is lost; read timeouts no longer terminate the listener loop
 - **Multicast reception**: acquire a `WifiManager.MulticastLock` during `init()` so the Wi-Fi stack does not filter SSDP multicast traffic
 - **Re-initialization**: `cleanup()` → `init()` cycles now work — coroutine scopes are recreated and the cache manager rebinds to the current scope
 - **Control URL**: default port to 80 when the device location URL has no explicit port (was producing `http://host:-1/...`)
-
-### ✨ Added
-- **`CastOptions` (#2)**: customize casting with `subtitleUri` (external subtitles, incl. Samsung `sec:SubtitleUri`), `subtitleMimeType`, `mimeType` and `upnpClass` overrides, or a full DIDL-Lite `metadata` override — available on `cast()`, `castToDevice()` and `castLocalFile()`
+- **`search()` semantics**: returns the complete device list after the timeout instead of resolving as soon as the first device responds
+- **Progress interpolation**: only advances while the transport state is `PLAYING` (previously any media with a known duration was treated as playing)
+- **Cache isolation**: switching devices drops all cached volume/progress state; casting new media on the same device resets the progress cache
 
 ### 🔧 Changed
 - `DeviceDescriptionParser` is now `internal` (was accidentally public)

--- a/app/src/main/java/com/yinnho/upnpcast/DLNACast.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/DLNACast.kt
@@ -118,9 +118,20 @@ object DLNACast {
     
     /**
      * Search for DLNA devices
+     *
+     * Returns the complete list of devices found within [timeout]; does not
+     * resolve early when the first device appears.
      */
-    suspend fun search(timeout: Long = 5000): List<Device> = 
-        suspendOnce { callback -> CoreManager.search(timeout, callback) }
+    suspend fun search(timeout: Long = 5000): List<Device> =
+        suspendCancellableCoroutine { cont ->
+            var resumed = false
+            CoreManager.search(timeout) { devices, complete ->
+                if (complete && !resumed) {
+                    resumed = true
+                    cont.resume(devices)
+                }
+            }
+        }
     
     /**
      * Cast media to best available device
@@ -142,8 +153,14 @@ object DLNACast {
     /**
      * Get current playback progress
      */
-    suspend fun getProgress(): Pair<Long, Long>? = 
+    suspend fun getProgress(): Pair<Long, Long>? =
         suspendWithTriple { callback -> CoreManager.getProgress(callback) }
+
+    /**
+     * Query the live playback state from the connected device
+     * (GetTransportInfo; reflects pause/stop on the device side)
+     */
+    suspend fun getPlaybackState(): PlaybackState = CoreManager.getPlaybackState()
     
     /**
      * Get volume information

--- a/app/src/main/java/com/yinnho/upnpcast/internal/core/CacheManager.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/core/CacheManager.kt
@@ -3,6 +3,8 @@ package com.yinnho.upnpcast.internal.core
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import com.yinnho.upnpcast.internal.discovery.RemoteDevice
 import com.yinnho.upnpcast.internal.media.DlnaMediaController
@@ -35,6 +37,14 @@ internal class CacheManager(
     private var lastProgressUpdate: Long = 0L
     @Volatile
     private var isPlaying: Boolean = false
+
+    /**
+     * Last observed AVTransport state (PLAYING / PAUSED_PLAYBACK / ...),
+     * null when never queried. Drives progress interpolation.
+     */
+    @Volatile
+    var cachedTransportState: String? = null
+        private set
     
     @Volatile
     private var volumeRefreshJob: Job? = null
@@ -128,14 +138,20 @@ internal class CacheManager(
         coreScope.launch {
             try {
                 val controller = DlnaMediaController.getController(device)
-                val progressInfo = controller.getPositionInfo()
-                
-                if (progressInfo != null) {
-                    val (currentMs, totalMs) = progressInfo
-                    updateProgressCache(currentMs, totalMs, System.currentTimeMillis())
-                    callback(true)
-                } else {
-                    callback(false)
+                coroutineScope {
+                    val positionDeferred = async { controller.getPositionInfo() }
+                    val stateDeferred = async { controller.getTransportInfo() }
+                    val progressInfo = positionDeferred.await()
+                    val transportState = stateDeferred.await()
+
+                    if (progressInfo != null) {
+                        val (currentMs, totalMs) = progressInfo
+                        cachedTransportState = transportState
+                        updateProgressCache(currentMs, totalMs, System.currentTimeMillis())
+                        callback(true)
+                    } else {
+                        callback(false)
+                    }
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh progress cache: ${e.message}")
@@ -186,6 +202,11 @@ internal class CacheManager(
         }
     }
     
+    fun updateTransportState(state: String?) {
+        cachedTransportState = state
+        updatePlayingState()
+    }
+
     private fun updateVolumeCache(volume: Int, muted: Boolean) {
         cachedVolume = volume
         cachedMuted = muted
@@ -200,9 +221,24 @@ internal class CacheManager(
     }
     
     private fun updatePlayingState() {
-        isPlaying = cachedTotalMs > 0
+        // Interpolate only from a confirmed PLAYING transport state; a
+        // paused device must not have its position advanced client-side
+        isPlaying = cachedTransportState == "PLAYING"
     }
-    
+
+    /**
+     * Clear progress caches (device kept, media changed)
+     */
+    fun clearProgress() {
+        cachedCurrentMs = 0L
+        cachedTotalMs = 0L
+        lastProgressUpdate = 0L
+        isPlaying = false
+        cachedTransportState = null
+        progressRefreshJob?.cancel()
+        progressRefreshJob = null
+    }
+
     /**
      * Clear all cached data
      */
@@ -210,16 +246,11 @@ internal class CacheManager(
         cachedVolume = -1
         cachedMuted = false
         lastVolumeUpdate = 0
-        
-        cachedCurrentMs = 0L
-        cachedTotalMs = 0L
-        lastProgressUpdate = 0L
-        isPlaying = false
-        
+
+        clearProgress()
+
         volumeRefreshJob?.cancel()
-        progressRefreshJob?.cancel()
         volumeRefreshJob = null
-        progressRefreshJob = null
     }
     
     /**

--- a/app/src/main/java/com/yinnho/upnpcast/internal/core/CoreManager.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/core/CoreManager.kt
@@ -97,27 +97,31 @@ internal class CoreManager {
         
         /**
          * Search for available DLNA devices
+         *
+         * [callback] fires with `complete = false` while devices are being
+         * discovered and exactly once with `complete = true` when the search
+         * finishes, carrying the full device list.
          */
-        fun search(timeout: Long, callback: (devices: List<Device>) -> Unit) {
+        fun search(timeout: Long, callback: (devices: List<Device>, complete: Boolean) -> Unit) {
             ensureInitialized {
                 cleanupSearchCallback()
-                
+
                 val foundDevices = mutableListOf<Device>()
-                
+
                 currentDeviceListCallback = { devices ->
                     foundDevices.clear()
                     foundDevices.addAll(devices)
-                    callback(devices)
+                    callback(devices, false)
                 }
-                
+
                 searchCompleted = false
                 notifiedDeviceIds.clear()
                 ssdpDiscovery?.startSearch()
-                
+
                 callbackTimeoutJob = ScopeManager.uiScope.launch {
                     delay(timeout)
                     searchCompleted = true
-                    callback(foundDevices)
+                    callback(getAllDevices(), true)
                     cleanupSearchCallback()
                 }
             }
@@ -134,13 +138,15 @@ internal class CoreManager {
                     connectAndPlay(bestDevice, url, title ?: "Media", options, callback)
                 } else {
                     Log.i(TAG, "No devices available, searching first...")
-                    search(3000) { devices ->
-                        if (devices.isNotEmpty()) {
-                            val bestDevice = selectBestDevice(devices)
-                            connectAndPlay(bestDevice, url, title ?: "Media", options, callback)
-                        } else {
-                            Log.w(TAG, "No devices found after search")
-                            callback(false)
+                    search(3000) { devices, complete ->
+                        if (complete) {
+                            if (devices.isNotEmpty()) {
+                                val bestDevice = selectBestDevice(devices)
+                                connectAndPlay(bestDevice, url, title ?: "Media", options, callback)
+                            } else {
+                                Log.w(TAG, "No devices found after search")
+                                callback(false)
+                            }
                         }
                     }
                 }
@@ -176,7 +182,7 @@ internal class CoreManager {
                 val remoteDevice = devices[device.id] ?: throw IllegalArgumentException("Device not found: ${device.id}")
                 val services = remoteDevice.details["services"] as? List<*>
                 if (!services.isNullOrEmpty()) {
-                    currentDevice = remoteDevice
+                    setCurrentDevice(remoteDevice)
                     ScopeManager.appScope.launch {
                         try {
                             val controller = DlnaMediaController.getController(remoteDevice)
@@ -237,12 +243,19 @@ internal class CoreManager {
         
         /**
          * Get current DLNA casting state
+         *
+         * The playback state reflects the last transport state observed via
+         * GetTransportInfo; call [getPlaybackState] for a live query.
          */
         fun getCurrentState(): State {
             val device = currentDevice?.let { convertToDevice(it) }
-            val playbackState = if (device != null) PlaybackState.PLAYING else PlaybackState.IDLE
+            val playbackState = if (device != null) {
+                mapTransportState(cacheManager.cachedTransportState)
+            } else {
+                PlaybackState.IDLE
+            }
             val (volume, muted) = cacheManager.getVolumeState()
-            
+
             return State(
                 isConnected = device != null,
                 currentDevice = device,
@@ -250,6 +263,33 @@ internal class CoreManager {
                 volume = if (volume >= 0) volume else -1,
                 isMuted = muted
             )
+        }
+
+        /**
+         * Query the live transport state from the connected device
+         */
+        suspend fun getPlaybackState(): PlaybackState {
+            val device = currentDevice ?: return PlaybackState.IDLE
+            return withContext(Dispatchers.IO) {
+                try {
+                    val controller = DlnaMediaController.getController(device)
+                    val state = controller.getTransportInfo()
+                    cacheManager.updateTransportState(state)
+                    mapTransportState(state)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to get playback state: ${e.message}")
+                    PlaybackState.IDLE
+                }
+            }
+        }
+
+        private fun mapTransportState(transportState: String?): PlaybackState = when (transportState) {
+            "PLAYING" -> PlaybackState.PLAYING
+            "PAUSED_PLAYBACK" -> PlaybackState.PAUSED
+            "TRANSITIONING" -> PlaybackState.BUFFERING
+            "STOPPED" -> PlaybackState.STOPPED
+            "NO_MEDIA_PRESENT", null -> PlaybackState.IDLE
+            else -> PlaybackState.IDLE
         }
         
         /**
@@ -315,7 +355,7 @@ internal class CoreManager {
                     return@ensureInitialized
                 }
 
-                currentDevice = remoteDevice
+                setCurrentDevice(remoteDevice)
                 LocalCastManager.castLocalFile(context, filePath, remoteDevice, title, options, ScopeManager.appScope, callback)
             }
         }
@@ -397,6 +437,20 @@ internal class CoreManager {
          */
         private inline fun <T> executeWithDevice(action: (RemoteDevice) -> T): T? {
             return currentDevice?.let(action)
+        }
+
+        /**
+         * Set the active device, isolating caches between devices: switching
+         * devices drops all cached state, re-casting on the same device
+         * drops only progress (media changed, device volume still valid)
+         */
+        private fun setCurrentDevice(remoteDevice: RemoteDevice) {
+            if (currentDevice?.id != remoteDevice.id) {
+                cacheManager.clearAll()
+            } else {
+                cacheManager.clearProgress()
+            }
+            currentDevice = remoteDevice
         }
         
 

--- a/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
@@ -306,6 +306,24 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
         needResponse = true,
         parser = ::parsePositionInfo
     )
+
+    /**
+     * Get transport state: PLAYING, PAUSED_PLAYBACK, STOPPED,
+     * TRANSITIONING or NO_MEDIA_PRESENT
+     */
+    suspend fun getTransportInfo(): String? = executeServiceAction(
+        serviceType = "AVTransport",
+        serviceNamespace = "urn:schemas-upnp-org:service:AVTransport:1",
+        defaultPath = "AVTransport/control",
+        action = "GetTransportInfo",
+        body = """
+            <u:GetTransportInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+                <InstanceID>0</InstanceID>
+            </u:GetTransportInfo>
+        """.trimIndent(),
+        needResponse = true,
+        parser = { response -> parseXmlValue(response, "CurrentTransportState") { it.trim() } }
+    )
     
     /**
      * Parse playback position information


### PR DESCRIPTION
## Summary
- `DLNACast.search()` now resolves after the timeout with the **complete** device list — previously it resolved as soon as the first device responded, so multi-device homes only ever saw one TV
- New `DLNACast.getPlaybackState()` performs a live `GetTransportInfo` query, so a pause/stop triggered on the device (remote control) is now visible to the app; `getState()` reports the last observed transport state instead of always claiming `PLAYING` while connected
- Progress interpolation only advances while the transport state is `PLAYING` (was: any media with a known duration was treated as playing, so paused playback drifted forward)
- Cache isolation: switching devices drops all cached volume/progress; re-casting on the same device resets only progress

## Test plan
- [x] `./gradlew test lint assembleRelease` green locally
- [x] Demo app compiles unchanged (all signatures source-compatible; `getState()` display handles all states already)
- [ ] Manual: pause via TV remote and confirm `getPlaybackState()` returns `PAUSED` — needs a real device