### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
         name: release-artifacts
         path: |
           app/build/outputs/aar/*
-          ~/.m2/repository/com/github/yinnho/UPnPCast/1.1.2/* 
+          ~/.m2/repository/com/github/yinnho/UPnPCast/1.2.0/* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the UPnPCast library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-09-02
 
 ### ✨ Added
 - **Live playback state**: `DLNACast.getPlaybackState()` queries the device via GetTransportInfo, so remote pauses/stops are reflected; `getState()` now reports the last observed transport state instead of always `PLAYING` while connected

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         minSdk = 24
         
         // Version information setting
-        version = "1.1.2"
+        version = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         
@@ -128,7 +128,7 @@ afterEvaluate {
                 
                 groupId = "com.yinnho.upnpcast"
                 artifactId = "upnpcast"
-                version = "1.1.2"
+                version = "1.2.0"
                 
                 pom {
                     name.set("UPnPCast")


### PR DESCRIPTION
## Summary
- Version bump 1.1.2 → 1.2.0 (`app/build.gradle.kts`, publishing block, CI artifact path)
- CHANGELOG `[Unreleased]` → `[1.2.0] - 2026-09-02` (issue #1 discovery fixes, CastOptions, live playback state, instance-based core refactor)

## Test plan
- [x] `./gradlew assembleRelease` passes
- [ ] CI green