### PR TITLE
Add unit tests and extract testable pure helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the UPnPCast library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Added
+- **Unit tests**: the project's first test suite (69 tests) covers DLNA time parsing/formatting, SOAP XML value extraction (position/volume/mute), DIDL-Lite metadata construction (MIME/class detection, XML escaping, subtitle resources, verbatim override), MIME type mapping and SSDP header parsing — making the CI `test` step meaningful
+
+### 🔧 Changed
+- Pure logic extracted from `DlnaMediaController`, `LocalFileServer` and `SsdpDeviceDiscovery` into internal helpers (`UpnpTime`, `SoapXml`, `MetadataBuilder`, `MimeTypes`, `SsdpHeaders`) with no behavior change
+
 ## [1.2.0] - 2026-09-02
 
 ### ✨ Added

--- a/app/src/main/java/com/yinnho/upnpcast/internal/discovery/SsdpDeviceDiscovery.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/discovery/SsdpDeviceDiscovery.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
+import com.yinnho.upnpcast.internal.util.SsdpHeaders
 
 /**
  * SSDP device discovery service
@@ -224,9 +225,9 @@ internal class SsdpDeviceDiscovery(
      */
     private fun processNotify(message: String, fromAddress: InetAddress) {
         try {
-            val nts = extractHeader(message, "NTS")
+            val nts = SsdpHeaders.extract(message, "NTS")
             if (nts == "ssdp:alive") {
-                val headers = parseSsdpHeaders(message)
+                val headers = SsdpHeaders.parse(message)
                 val location = headers["location"]
                 
                 if (location != null) {
@@ -241,9 +242,9 @@ internal class SsdpDeviceDiscovery(
                     processSsdpResponse(message, fromAddress)
                 }
             } else if (nts == "ssdp:byebye") {
-                val usn = extractHeader(message, "USN")
+                val usn = SsdpHeaders.extract(message, "USN")
                 if (usn != null) {
-                    val headers = parseSsdpHeaders(message)
+                    val headers = SsdpHeaders.parse(message)
                     val location = headers["location"]
                     if (location != null) {
                         synchronized(processedLock) {
@@ -259,35 +260,11 @@ internal class SsdpDeviceDiscovery(
     }
 
     /**
-     * Extract HTTP header information
-     */
-    private fun extractHeader(message: String, headerName: String): String? {
-        val regex = "$headerName:\\s*(.+)".toRegex(RegexOption.IGNORE_CASE)
-        return regex.find(message)?.groupValues?.get(1)?.trim()
-    }
-
-    /**
-     * Parse SSDP header information
-     */
-    private fun parseSsdpHeaders(message: String): Map<String, String> {
-        val headers = mutableMapOf<String, String>()
-        message.lines().forEach { line ->
-            val colonIndex = line.indexOf(':')
-            if (colonIndex > 0) {
-                val key = line.substring(0, colonIndex).trim().lowercase()
-                val value = line.substring(colonIndex + 1).trim()
-                headers[key] = value
-            }
-        }
-        return headers
-    }
-
-    /**
      * Process SSDP response
      */
     private fun processSsdpResponse(response: String, fromAddress: InetAddress) {
         try {
-            val headers = parseSsdpHeaders(response)
+            val headers = SsdpHeaders.parse(response)
             val location = headers["location"]
             val usn = headers["usn"]
             

--- a/app/src/main/java/com/yinnho/upnpcast/internal/localcast/LocalFileServer.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/localcast/LocalFileServer.kt
@@ -8,6 +8,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.lang.ref.WeakReference
 import kotlin.random.Random
+import com.yinnho.upnpcast.internal.util.MimeTypes
 
 /**
  * Local file server based on NanoHTTPD
@@ -226,7 +227,7 @@ internal class LocalFileServer private constructor(
 
         val response = newFixedLengthResponse(
             if (rangeHeader != null) Response.Status.PARTIAL_CONTENT else Response.Status.OK,
-            getMimeType(file.name),
+            MimeTypes.fromFileName(file.name),
             inputStream,
             contentLength
         )
@@ -246,29 +247,5 @@ internal class LocalFileServer private constructor(
 
         Log.d(TAG, "Serving file: ${file.name}, range: $rangeStart-$rangeEnd/$fileSize")
         return response
-    }
-
-    /**
-     * Resolve MIME type from the file extension; some TVs reject or
-     * mis-handle unknown content types.
-     */
-    private fun getMimeType(fileName: String): String {
-        val extension = fileName.substringAfterLast('.', "").lowercase()
-        return when (extension) {
-            "mp4", "m4v" -> "video/mp4"
-            "mkv", "webm" -> "video/x-matroska"
-            "avi" -> "video/x-msvideo"
-            "mov" -> "video/quicktime"
-            "ts", "m2ts" -> "video/mp2t"
-            "flv" -> "video/x-flv"
-            "3gp" -> "video/3gpp"
-            "mp3" -> "audio/mpeg"
-            "flac" -> "audio/flac"
-            "aac", "m4a" -> "audio/mp4"
-            "wav" -> "audio/x-wav"
-            "ogg", "oga" -> "audio/ogg"
-            "srt" -> "text/srt"
-            else -> "application/octet-stream"
-        }
     }
 }

--- a/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
@@ -11,6 +11,9 @@ import java.util.Locale
 import com.yinnho.upnpcast.CastOptions
 import com.yinnho.upnpcast.internal.discovery.RemoteDevice
 import com.yinnho.upnpcast.internal.discovery.DeviceDescriptionParser
+import com.yinnho.upnpcast.internal.util.MetadataBuilder
+import com.yinnho.upnpcast.internal.util.SoapXml
+import com.yinnho.upnpcast.internal.util.UpnpTime
 
 /**
  * DLNA media controller with SOAP-based control implementation
@@ -93,7 +96,7 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
         if (!checkAvailable()) return@withContext false
 
         try {
-            val setUriSuccess = setMediaUri(mediaUrl, createMetadata(title, episodeLabel, mediaUrl, options))
+            val setUriSuccess = setMediaUri(mediaUrl, MetadataBuilder.build(title, episodeLabel, mediaUrl, options))
             if (!setUriSuccess) return@withContext false
             
             val playSuccess = control("play")
@@ -216,7 +219,7 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
                     is String -> value.toLongOrNull() ?: return false
                     else -> return false
                 }
-                val timeString = formatTime(positionMs)
+                val timeString = UpnpTime.format(positionMs)
                 executeAVTransportAction("Seek", "\n                        <Unit>REL_TIME</Unit>\n                        <Target>${escapeXmlContent(timeString)}</Target>")
             }
             
@@ -263,7 +266,7 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
             </u:GetPositionInfo>
         """.trimIndent(),
         needResponse = true,
-        parser = ::parsePositionInfo
+        parser = SoapXml::parsePositionInfo
     )
 
     /**
@@ -281,53 +284,8 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
             </u:GetTransportInfo>
         """.trimIndent(),
         needResponse = true,
-        parser = { response -> parseXmlValue(response, "CurrentTransportState") { it.trim() } }
+        parser = { response -> SoapXml.extractValue(response, "CurrentTransportState")?.trim() }
     )
-    
-    /**
-     * Parse playback position information
-     */
-    private fun parsePositionInfo(response: String): Pair<Long, Long>? {
-        try {
-            // Simple XML parsing to get RelTime and TrackDuration
-            val relTimePattern = "<RelTime>(.*?)</RelTime>".toRegex()
-            val durationPattern = "<TrackDuration>(.*?)</TrackDuration>".toRegex()
-            
-            val relTimeMatch = relTimePattern.find(response)
-            val durationMatch = durationPattern.find(response)
-            
-            val currentTime = relTimeMatch?.groupValues?.get(1)?.let { parseTimeToMs(it) } ?: 0L
-            val totalTime = durationMatch?.groupValues?.get(1)?.let { parseTimeToMs(it) } ?: 0L
-            
-            return Pair(currentTime, totalTime)
-        } catch (e: Exception) {
-            Log.e(tag, "Failed to parse position info: ${e.message}")
-            return null
-        }
-    }
-    
-    /**
-     * Parse time string to milliseconds
-     */
-    private fun parseTimeToMs(timeString: String): Long {
-        try {
-            if (timeString == "NOT_IMPLEMENTED" || timeString.isEmpty()) {
-                return 0L
-            }
-            
-            val parts = timeString.split(":")
-            if (parts.size == 3) {
-                val hours = parts[0].toLongOrNull() ?: 0L
-                val minutes = parts[1].toLongOrNull() ?: 0L
-                val seconds = parts[2].toDoubleOrNull() ?: 0.0
-                
-                return (hours * 3600 + minutes * 60 + seconds).toLong() * 1000
-            }
-            return 0L
-        } catch (e: Exception) {
-            return 0L
-        }
-    }
     
     /**
      * Generic SOAP request - handles both Boolean and String responses
@@ -388,42 +346,6 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
     }
     
     /**
-     * Generic XML value parser
-     */
-    private fun <T> parseXmlValue(
-        response: String, 
-        tagName: String, 
-        converter: (String) -> T?
-    ): T? {
-        try {
-            val pattern = "<$tagName>(.*?)</$tagName>".toRegex()
-            val match = pattern.find(response)
-            return match?.groupValues?.get(1)?.let { converter(it) }
-        } catch (e: Exception) {
-            Log.e(tag, "Failed to parse $tagName from response: ${e.message}")
-            return null
-        }
-    }
-    
-    /**
-     * Parse volume from response
-     */
-    private fun parseVolumeFromResponse(response: String): Int? = 
-        parseXmlValue(response, "CurrentVolume") { it.toIntOrNull() }
-    
-    /**
-     * Parse mute state from response
-     */
-    private fun parseMuteFromResponse(response: String): Boolean? = 
-        parseXmlValue(response, "CurrentMute") { value ->
-            when (value) {
-                "1", "true", "True" -> true
-                "0", "false", "False" -> false
-                else -> null
-            }
-        }
-    
-    /**
      * Basic XML escape (common characters)
      */
     private fun escapeXmlBasic(text: String): String {
@@ -446,70 +368,7 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
      * XML escape for URLs (basic only)
      */
     private fun escapeXmlUrl(url: String): String = escapeXmlBasic(url)
-    
-    /**
-     * Create DIDL-Lite metadata
-     *
-     * [CastOptions.metadata] is sent verbatim when provided. Otherwise the
-     * metadata is generated, honoring the mimeType/upnpClass overrides and
-     * attaching the subtitle resource when [CastOptions.subtitleUri] is set
-     * (the Samsung `sec:SubtitleUri` extension is included as well).
-     */
-    private fun createMetadata(
-        title: String,
-        episodeLabel: String,
-        mediaUrl: String = "",
-        options: CastOptions = CastOptions()
-    ): String {
-        options.metadata?.let { return it }
 
-        val displayTitle = if (episodeLabel.isNotEmpty()) "$title - $episodeLabel" else title
-        val safeDisplayTitle = escapeXmlContent(displayTitle)
-        val safeMediaUrl = escapeXmlUrl(mediaUrl)
-
-        val mediaType = options.mimeType ?: when {
-            mediaUrl.contains(".mp4", ignoreCase = true) -> "video/mp4"
-            mediaUrl.contains(".mkv", ignoreCase = true) -> "video/x-matroska"
-            mediaUrl.contains(".m3u8", ignoreCase = true) -> "application/vnd.apple.mpegurl"
-            mediaUrl.contains(".mp3", ignoreCase = true) -> "audio/mpeg"
-            else -> "video/mp4"
-        }
-
-        val upnpClass = options.upnpClass ?: if (mediaType.startsWith("video") || mediaType.contains("mpegurl")) {
-            "object.item.videoItem"
-        } else {
-            "object.item.audioItem.musicTrack"
-        }
-
-        val safeSubtitleUri = options.subtitleUri?.let { escapeXmlUrl(it) }
-        val subtitleRes = safeSubtitleUri
-            ?.let { "\n        <res protocolInfo=\"http-get:*:${options.subtitleMimeType}:*\">$it</res>" }
-            ?: ""
-        val subtitleElement = safeSubtitleUri
-            ?.let { "\n        <sec:SubtitleUri>$it</sec:SubtitleUri>" }
-            ?: ""
-        val secNamespace = if (safeSubtitleUri != null) " xmlns:sec=\"http://www.samsung.com/sec/\"" else ""
-
-        return """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"$secNamespace>
-    <item id="1" parentID="0" restricted="1">
-        <dc:title>$safeDisplayTitle</dc:title>
-        <upnp:class>$upnpClass</upnp:class>$subtitleElement
-        <res protocolInfo="http-get:*:$mediaType:*">$safeMediaUrl</res>$subtitleRes
-    </item>
-</DIDL-Lite>"""
-    }
-    
-    /**
-     * Time format
-     */
-    private fun formatTime(positionMs: Long): String {
-        val totalSeconds = positionMs / 1000
-        val hours = totalSeconds / 3600
-        val minutes = (totalSeconds % 3600) / 60
-        val seconds = totalSeconds % 60
-        return String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds)
-    }
-    
     /**
      * Execute RenderingControl action - unified method for both set and get operations
      */
@@ -538,12 +397,12 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
     /**
      * Get current volume
      */
-    suspend fun getVolumeAsync(): Int? = executeRenderingControl("GetVolume", needResponse = true, parser = ::parseVolumeFromResponse)
+    suspend fun getVolumeAsync(): Int? = executeRenderingControl("GetVolume", needResponse = true, parser = SoapXml::parseVolume)
     
     /**
      * Get current mute state
      */
-    suspend fun getMuteAsync(): Boolean? = executeRenderingControl("GetMute", needResponse = true, parser = ::parseMuteFromResponse)
+    suspend fun getMuteAsync(): Boolean? = executeRenderingControl("GetMute", needResponse = true, parser = SoapXml::parseMute)
     
 
     

--- a/app/src/main/java/com/yinnho/upnpcast/internal/util/MetadataBuilder.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/util/MetadataBuilder.kt
@@ -1,0 +1,75 @@
+package com.yinnho.upnpcast.internal.util
+
+import com.yinnho.upnpcast.CastOptions
+
+/**
+ * DIDL-Lite metadata construction for AVTransport SetAVTransportURI
+ *
+ * [CastOptions.metadata] is sent verbatim when provided. Otherwise the
+ * metadata is generated, honoring the mimeType/upnpClass overrides and
+ * attaching the subtitle resource when [CastOptions.subtitleUri] is set
+ * (the Samsung `sec:SubtitleUri` extension is included as well).
+ */
+internal object MetadataBuilder {
+
+    private fun escapeXmlBasic(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+    }
+
+    private fun escapeXmlContent(text: String): String {
+        return escapeXmlBasic(text)
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;")
+    }
+
+    private fun escapeXmlUrl(url: String): String = escapeXmlBasic(url)
+
+    fun detectMimeType(url: String): String = when {
+        url.contains(".mp4", ignoreCase = true) -> "video/mp4"
+        url.contains(".mkv", ignoreCase = true) -> "video/x-matroska"
+        url.contains(".m3u8", ignoreCase = true) -> "application/vnd.apple.mpegurl"
+        url.contains(".mp3", ignoreCase = true) -> "audio/mpeg"
+        else -> "video/mp4"
+    }
+
+    fun build(
+        title: String,
+        episodeLabel: String = "",
+        mediaUrl: String = "",
+        options: CastOptions = CastOptions()
+    ): String {
+        options.metadata?.let { return it }
+
+        val displayTitle = if (episodeLabel.isNotEmpty()) "$title - $episodeLabel" else title
+        val safeDisplayTitle = escapeXmlContent(displayTitle)
+        val safeMediaUrl = escapeXmlUrl(mediaUrl)
+
+        val mediaType = options.mimeType ?: detectMimeType(mediaUrl)
+
+        val upnpClass = options.upnpClass ?: if (mediaType.startsWith("video") || mediaType.contains("mpegurl")) {
+            "object.item.videoItem"
+        } else {
+            "object.item.audioItem.musicTrack"
+        }
+
+        val safeSubtitleUri = options.subtitleUri?.let { escapeXmlUrl(it) }
+        val subtitleRes = safeSubtitleUri
+            ?.let { "\n        <res protocolInfo=\"http-get:*:${options.subtitleMimeType}:*\">$it</res>" }
+            ?: ""
+        val subtitleElement = safeSubtitleUri
+            ?.let { "\n        <sec:SubtitleUri>$it</sec:SubtitleUri>" }
+            ?: ""
+        val secNamespace = if (safeSubtitleUri != null) " xmlns:sec=\"http://www.samsung.com/sec/\"" else ""
+
+        return """<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"$secNamespace>
+    <item id="1" parentID="0" restricted="1">
+        <dc:title>$safeDisplayTitle</dc:title>
+        <upnp:class>$upnpClass</upnp:class>$subtitleElement
+        <res protocolInfo="http-get:*:$mediaType:*">$safeMediaUrl</res>$subtitleRes
+    </item>
+</DIDL-Lite>"""
+    }
+}

--- a/app/src/main/java/com/yinnho/upnpcast/internal/util/MimeTypes.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/util/MimeTypes.kt
@@ -1,0 +1,28 @@
+package com.yinnho.upnpcast.internal.util
+
+/**
+ * Resolve MIME type from the file extension; some TVs reject or
+ * mis-handle unknown content types.
+ */
+internal object MimeTypes {
+
+    fun fromFileName(fileName: String): String {
+        val extension = fileName.substringAfterLast('.', "").lowercase()
+        return when (extension) {
+            "mp4", "m4v" -> "video/mp4"
+            "mkv", "webm" -> "video/x-matroska"
+            "avi" -> "video/x-msvideo"
+            "mov" -> "video/quicktime"
+            "ts", "m2ts" -> "video/mp2t"
+            "flv" -> "video/x-flv"
+            "3gp" -> "video/3gpp"
+            "mp3" -> "audio/mpeg"
+            "flac" -> "audio/flac"
+            "aac", "m4a" -> "audio/mp4"
+            "wav" -> "audio/x-wav"
+            "ogg", "oga" -> "audio/ogg"
+            "srt" -> "text/srt"
+            else -> "application/octet-stream"
+        }
+    }
+}

--- a/app/src/main/java/com/yinnho/upnpcast/internal/util/SoapXml.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/util/SoapXml.kt
@@ -1,0 +1,42 @@
+package com.yinnho.upnpcast.internal.util
+
+/**
+ * Minimal regex-based extraction of values from SOAP action responses
+ */
+internal object SoapXml {
+
+    fun extractValue(response: String, tagName: String): String? {
+        return try {
+            val pattern = "<$tagName>(.*?)</$tagName>".toRegex()
+            pattern.find(response)?.groupValues?.get(1)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Parse GetPositionInfo response into (currentMs, totalMs); missing
+     * fields default to 0
+     */
+    fun parsePositionInfo(response: String): Pair<Long, Long>? {
+        return try {
+            val currentTime = extractValue(response, "RelTime")?.let { UpnpTime.parseToMs(it) } ?: 0L
+            val totalTime = extractValue(response, "TrackDuration")?.let { UpnpTime.parseToMs(it) } ?: 0L
+            Pair(currentTime, totalTime)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun parseVolume(response: String): Int? =
+        extractValue(response, "CurrentVolume")?.toIntOrNull()
+
+    fun parseMute(response: String): Boolean? =
+        extractValue(response, "CurrentMute")?.let { value ->
+            when (value) {
+                "1", "true", "True" -> true
+                "0", "false", "False" -> false
+                else -> null
+            }
+        }
+}

--- a/app/src/main/java/com/yinnho/upnpcast/internal/util/SsdpHeaders.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/util/SsdpHeaders.kt
@@ -1,0 +1,25 @@
+package com.yinnho.upnpcast.internal.util
+
+/**
+ * SSDP message header parsing
+ */
+internal object SsdpHeaders {
+
+    fun parse(message: String): Map<String, String> {
+        val headers = mutableMapOf<String, String>()
+        message.lines().forEach { line ->
+            val colonIndex = line.indexOf(':')
+            if (colonIndex > 0) {
+                val key = line.substring(0, colonIndex).trim().lowercase()
+                val value = line.substring(colonIndex + 1).trim()
+                headers[key] = value
+            }
+        }
+        return headers
+    }
+
+    fun extract(message: String, headerName: String): String? {
+        val regex = "$headerName:\\s*(.+)".toRegex(RegexOption.IGNORE_CASE)
+        return regex.find(message)?.groupValues?.get(1)?.trim()
+    }
+}

--- a/app/src/main/java/com/yinnho/upnpcast/internal/util/UpnpTime.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/util/UpnpTime.kt
@@ -1,0 +1,37 @@
+package com.yinnho.upnpcast.internal.util
+
+import java.util.Locale
+
+/**
+ * DLNA time format conversions (HH:MM:SS ↔ milliseconds)
+ */
+internal object UpnpTime {
+
+    fun parseToMs(timeString: String): Long {
+        try {
+            if (timeString == "NOT_IMPLEMENTED" || timeString.isEmpty()) {
+                return 0L
+            }
+
+            val parts = timeString.split(":")
+            if (parts.size == 3) {
+                val hours = parts[0].toLongOrNull() ?: 0L
+                val minutes = parts[1].toLongOrNull() ?: 0L
+                val seconds = parts[2].toDoubleOrNull() ?: 0.0
+
+                return (hours * 3600 + minutes * 60 + seconds).toLong() * 1000
+            }
+            return 0L
+        } catch (e: Exception) {
+            return 0L
+        }
+    }
+
+    fun format(positionMs: Long): String {
+        val totalSeconds = positionMs / 1000
+        val hours = totalSeconds / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val seconds = totalSeconds % 60
+        return String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/util/MetadataBuilderTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/util/MetadataBuilderTest.kt
@@ -1,0 +1,103 @@
+package com.yinnho.upnpcast.internal.util
+
+import com.yinnho.upnpcast.CastOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MetadataBuilderTest {
+
+    @Test
+    fun buildsDefaultVideoMetadataForMp4Url() {
+        val metadata = MetadataBuilder.build(title = "Movie", mediaUrl = "http://host/video.mp4")
+
+        assertTrue(metadata.startsWith("<DIDL-Lite"))
+        assertTrue(metadata.contains("<dc:title>Movie</dc:title>"))
+        assertTrue(metadata.contains("<upnp:class>object.item.videoItem</upnp:class>"))
+        assertTrue(metadata.contains("<res protocolInfo=\"http-get:*:video/mp4:*\">http://host/video.mp4</res>"))
+        assertFalse(metadata.contains("sec:"))
+    }
+
+    @Test
+    fun detectsMimeTypesFromUrl() {
+        assertEquals("video/x-matroska", MetadataBuilder.detectMimeType("http://h/a.mkv"))
+        assertEquals("application/vnd.apple.mpegurl", MetadataBuilder.detectMimeType("http://h/a.m3u8"))
+        assertEquals("audio/mpeg", MetadataBuilder.detectMimeType("http://h/a.mp3"))
+        assertEquals("video/mp4", MetadataBuilder.detectMimeType("http://h/a.dat"))
+    }
+
+    @Test
+    fun audioMimeTypeYieldsMusicTrackClass() {
+        val metadata = MetadataBuilder.build(title = "Song", mediaUrl = "http://host/song.mp3")
+        assertTrue(metadata.contains("<upnp:class>object.item.audioItem.musicTrack</upnp:class>"))
+        assertTrue(metadata.contains("audio/mpeg"))
+    }
+
+    @Test
+    fun mimeTypeOverrideChangesProtocolInfoAndClass() {
+        val metadata = MetadataBuilder.build(
+            title = "X",
+            mediaUrl = "http://host/file.dat",
+            options = CastOptions(mimeType = "video/x-msvideo")
+        )
+        assertTrue(metadata.contains("http-get:*:video/x-msvideo:*"))
+        assertTrue(metadata.contains("object.item.videoItem"))
+    }
+
+    @Test
+    fun upnpClassOverrideIsUsed() {
+        val metadata = MetadataBuilder.build(
+            title = "X",
+            mediaUrl = "http://host/video.mp4",
+            options = CastOptions(upnpClass = "object.item.imageItem")
+        )
+        assertTrue(metadata.contains("<upnp:class>object.item.imageItem</upnp:class>"))
+    }
+
+    @Test
+    fun episodeLabelIsAppendedToTitle() {
+        val metadata = MetadataBuilder.build(title = "Show", episodeLabel = "S01E01", mediaUrl = "http://h/v.mp4")
+        assertTrue(metadata.contains("<dc:title>Show - S01E01</dc:title>"))
+    }
+
+    @Test
+    fun escapesXmlSpecialCharactersInTitle() {
+        val metadata = MetadataBuilder.build(title = "A<B> & \"C\" 'D'", mediaUrl = "http://h/v.mp4")
+        assertTrue(metadata.contains("<dc:title>A&lt;B&gt; &amp; &quot;C&quot; &apos;D&apos;</dc:title>"))
+        assertFalse(metadata.contains("A<B>"))
+    }
+
+    @Test
+    fun subtitleUriAddsResAndSamsungExtension() {
+        val metadata = MetadataBuilder.build(
+            title = "Movie",
+            mediaUrl = "http://host/video.mp4",
+            options = CastOptions(subtitleUri = "http://host/sub.srt")
+        )
+        assertTrue(metadata.contains("xmlns:sec=\"http://www.samsung.com/sec/\""))
+        assertTrue(metadata.contains("<res protocolInfo=\"http-get:*:text/srt:*\">http://host/sub.srt</res>"))
+        assertTrue(metadata.contains("<sec:SubtitleUri>http://host/sub.srt</sec:SubtitleUri>"))
+    }
+
+    @Test
+    fun subtitleMimeTypeOverrideIsReflectedInProtocolInfo() {
+        val metadata = MetadataBuilder.build(
+            title = "Movie",
+            mediaUrl = "http://host/video.mp4",
+            options = CastOptions(subtitleUri = "http://host/sub.vtt", subtitleMimeType = "text/vtt")
+        )
+        assertTrue(metadata.contains("http-get:*:text/vtt:*"))
+    }
+
+    @Test
+    fun verbatimMetadataOverrideShortCircuitsGeneration() {
+        val custom = "<DIDL-Lite><item id=\"custom\"/></DIDL-Lite>"
+        val metadata = MetadataBuilder.build(
+            title = "Ignored",
+            mediaUrl = "http://host/video.mp4",
+            options = CastOptions(metadata = custom)
+        )
+        assertEquals(custom, metadata)
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/util/MimeTypesTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/util/MimeTypesTest.kt
@@ -1,0 +1,41 @@
+package com.yinnho.upnpcast.internal.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class MimeTypesTest {
+
+    @ParameterizedTest(name = "\"{0}\" -> \"{1}\"")
+    @CsvSource(
+        "video.mp4, video/mp4",
+        "video.MP4, video/mp4",
+        "video.m4v, video/mp4",
+        "movie.mkv, video/x-matroska",
+        "clip.webm, video/x-matroska",
+        "old.avi, video/x-msvideo",
+        "iphone.mov, video/quicktime",
+        "stream.ts, video/mp2t",
+        "stream.m2ts, video/mp2t",
+        "flash.flv, video/x-flv",
+        "mobile.3gp, video/3gpp",
+        "song.mp3, audio/mpeg",
+        "lossless.flac, audio/flac",
+        "audio.aac, audio/mp4",
+        "audio.m4a, audio/mp4",
+        "pcm.wav, audio/x-wav",
+        "vorbis.ogg, audio/ogg",
+        "vorbis.oga, audio/ogg",
+        "subs.srt, text/srt",
+        "archive.zip, application/octet-stream",
+        "noextension, application/octet-stream"
+    )
+    fun mapsExtensionsToMimeTypes(fileName: String, expected: String) {
+        assertEquals(expected, MimeTypes.fromFileName(fileName))
+    }
+
+    @org.junit.jupiter.api.Test
+    fun handlesMultiDotFileNames() {
+        assertEquals("video/mp4", MimeTypes.fromFileName("my.movie.2024.mp4"))
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/util/SoapXmlTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/util/SoapXmlTest.kt
@@ -1,0 +1,89 @@
+package com.yinnho.upnpcast.internal.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SoapXmlTest {
+
+    private val positionResponse = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+            <s:Body>
+                <u:GetPositionInfoResponse xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">
+                    <Track>1</Track>
+                    <TrackDuration>01:30:00</TrackDuration>
+                    <TrackMetaData>not xml</TrackMetaData>
+                    <TrackURI>http://example.com/video.mp4</TrackURI>
+                    <RelTime>00:00:45</RelTime>
+                    <AbsTime>00:00:45</AbsTime>
+                </u:GetPositionInfoResponse>
+            </s:Body>
+        </s:Envelope>
+    """.trimIndent()
+
+    @Test
+    fun extractsSimpleTagValue() {
+        assertEquals("00:00:45", SoapXml.extractValue(positionResponse, "RelTime"))
+    }
+
+    @Test
+    fun returnsNullForMissingTag() {
+        assertNull(SoapXml.extractValue(positionResponse, "NoSuchTag"))
+    }
+
+    @Test
+    fun parsePositionInfoReturnsCurrentAndTotal() {
+        assertEquals(Pair(45000L, 5400000L), SoapXml.parsePositionInfo(positionResponse))
+    }
+
+    @Test
+    fun parsePositionInfoDefaultsMissingFieldsToZero() {
+        val response = "<u:GetPositionInfoResponse><RelTime>00:00:10</RelTime></u:GetPositionInfoResponse>"
+        assertEquals(Pair(10000L, 0L), SoapXml.parsePositionInfo(response))
+    }
+
+    @Test
+    fun parsePositionInfoTreatsNotImplementedAsZero() {
+        val response = "<u:GetPositionInfoResponse>" +
+            "<TrackDuration>NOT_IMPLEMENTED</TrackDuration>" +
+            "<RelTime>NOT_IMPLEMENTED</RelTime>" +
+            "</u:GetPositionInfoResponse>"
+        assertEquals(Pair(0L, 0L), SoapXml.parsePositionInfo(response))
+    }
+
+    @Test
+    fun parseVolumeParsesInteger() {
+        assertEquals(30, SoapXml.parseVolume("<CurrentVolume>30</CurrentVolume>"))
+        assertEquals(0, SoapXml.parseVolume("<CurrentVolume>0</CurrentVolume>"))
+        assertEquals(100, SoapXml.parseVolume("<CurrentVolume>100</CurrentVolume>"))
+    }
+
+    @Test
+    fun parseVolumeReturnsNullForNonNumeric() {
+        assertNull(SoapXml.parseVolume("<CurrentVolume>loud</CurrentVolume>"))
+        assertNull(SoapXml.parseVolume("<NoVolume>5</NoVolume>"))
+    }
+
+    @Test
+    fun parseMuteRecognizesTrueValues() {
+        assertTrue(SoapXml.parseMute("<CurrentMute>1</CurrentMute>")!!)
+        assertTrue(SoapXml.parseMute("<CurrentMute>true</CurrentMute>")!!)
+        assertTrue(SoapXml.parseMute("<CurrentMute>True</CurrentMute>")!!)
+    }
+
+    @Test
+    fun parseMuteRecognizesFalseValues() {
+        assertFalse(SoapXml.parseMute("<CurrentMute>0</CurrentMute>")!!)
+        assertFalse(SoapXml.parseMute("<CurrentMute>false</CurrentMute>")!!)
+        assertFalse(SoapXml.parseMute("<CurrentMute>False</CurrentMute>")!!)
+    }
+
+    @Test
+    fun parseMuteReturnsNullForUnknownValue() {
+        assertNull(SoapXml.parseMute("<CurrentMute>maybe</CurrentMute>"))
+        assertNull(SoapXml.parseMute("<NoMute>1</NoMute>"))
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/util/SsdpHeadersTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/util/SsdpHeadersTest.kt
@@ -1,0 +1,65 @@
+package com.yinnho.upnpcast.internal.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SsdpHeadersTest {
+
+    private val mSearchResponse = """
+        HTTP/1.1 200 OK
+        CACHE-CONTROL: max-age=1800
+        LOCATION: http://192.168.1.100:49152/description.xml
+        ST: urn:schemas-upnp-org:device:MediaRenderer:1
+        USN: uuid:abc-123::urn:schemas-upnp-org:device:MediaRenderer:1
+        SERVER: Linux/1.0 UPnP/1.0 Renderer/1.0
+
+    """.trimIndent()
+
+    private val notify = """
+        NOTIFY * HTTP/1.1
+        HOST: 239.255.255.250:1900
+        NTS: ssdp:alive
+        NT: urn:schemas-upnp-org:device:MediaRenderer:1
+        USN: uuid:abc-123
+        LOCATION: http://192.168.1.100:49152/description.xml
+
+    """.trimIndent()
+
+    @Test
+    fun parsesHeadersWithLowercaseKeys() {
+        val headers = SsdpHeaders.parse(mSearchResponse)
+
+        assertEquals("http://192.168.1.100:49152/description.xml", headers["location"])
+        assertEquals("uuid:abc-123::urn:schemas-upnp-org:device:MediaRenderer:1", headers["usn"])
+        assertEquals("max-age=1800", headers["cache-control"])
+    }
+
+    @Test
+    fun parseIgnoresLinesWithoutColon() {
+        val headers = SsdpHeaders.parse("HTTP/1.1 200 OK\nUSN: uuid:1\n")
+        assertEquals(mapOf("usn" to "uuid:1"), headers)
+    }
+
+    @Test
+    fun parseTrimsWhitespaceAroundValues() {
+        val headers = SsdpHeaders.parse("NTS:   ssdp:alive  \n")
+        assertEquals("ssdp:alive", headers["nts"])
+    }
+
+    @Test
+    fun extractIsCaseInsensitiveOnHeaderName() {
+        assertEquals("ssdp:alive", SsdpHeaders.extract(notify, "NTS"))
+        assertEquals("ssdp:alive", SsdpHeaders.extract(notify, "nts"))
+    }
+
+    @Test
+    fun extractReturnsNullForMissingHeader() {
+        assertNull(SsdpHeaders.extract(notify, "SERVER"))
+    }
+
+    @Test
+    fun extractTrimsValue() {
+        assertEquals("uuid:abc-123", SsdpHeaders.extract(notify, "USN"))
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/util/UpnpTimeTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/util/UpnpTimeTest.kt
@@ -1,0 +1,58 @@
+package com.yinnho.upnpcast.internal.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class UpnpTimeTest {
+
+    @ParameterizedTest(name = "parseToMs(\"{0}\") == {1}")
+    @CsvSource(
+        "00:00:00, 0",
+        "00:00:01, 1000",
+        "00:01:30, 90000",
+        "01:00:00, 3600000",
+        "01:02:03, 3723000",
+        "10:00:00, 36000000",
+        "100:00:00, 360000000"
+    )
+    fun parsesStandardTimeStrings(input: String, expectedMs: Long) {
+        assertEquals(expectedMs, UpnpTime.parseToMs(input))
+    }
+
+    @ParameterizedTest(name = "parseToMs(\"{0}\") == 0")
+    @ValueSource(strings = ["NOT_IMPLEMENTED", "", "12:34", "abc", "aa:bb:cc"])
+    fun returnsZeroForNonParseableInput(input: String) {
+        assertEquals(0L, UpnpTime.parseToMs(input))
+    }
+
+    @org.junit.jupiter.api.Test
+    fun truncatesFractionalSeconds() {
+        assertEquals(90000L, UpnpTime.parseToMs("00:01:30.500"))
+    }
+
+    @ParameterizedTest(name = "format({0}) == \"{1}\"")
+    @CsvSource(
+        "0, 00:00:00",
+        "1000, 00:00:01",
+        "90000, 00:01:30",
+        "3600000, 01:00:00",
+        "3723000, 01:02:03",
+        "360000000, 100:00:00"
+    )
+    fun formatsMillisecondsAsColonTime(ms: Long, expected: String) {
+        assertEquals(expected, UpnpTime.format(ms))
+    }
+
+    @org.junit.jupiter.api.Test
+    fun formatIgnoresSubSecondPrecision() {
+        assertEquals("00:00:01", UpnpTime.format(1999L))
+    }
+
+    @org.junit.jupiter.api.Test
+    fun parseAndFormatRoundTrip() {
+        val original = "02:34:56"
+        assertEquals(original, UpnpTime.format(UpnpTime.parseToMs(original)))
+    }
+}


### PR DESCRIPTION
## Summary
- Extract pure logic into internal util objects (no behavior change):
  - `UpnpTime` — DLNA `HH:MM:SS` ↔ ms conversion (was private in `DlnaMediaController`)
  - `SoapXml` — SOAP response value extraction: position, volume, mute
  - `MetadataBuilder` — DIDL-Lite construction: MIME/class detection, escaping, subtitle resources, verbatim override (was `createMetadata`)
  - `MimeTypes` — file-extension MIME mapping (was private in `LocalFileServer`)
  - `SsdpHeaders` — SSDP header parse/extract (was private in `SsdpDeviceDiscovery`)
- First unit test suite in the project: 69 JUnit 5 tests across the five helpers — the CI `test` step previously ran zero tests
- Foundation for the v1.3.0 roadmap (typed `RemoteDevice`, unified HTTP layer) since the parsing layer is now verifiable

## Test plan
- [x] `./gradlew test lint assembleRelease` passes locally; 69/69 tests green
- [ ] CI green