### PR TITLE
Type RemoteDevice fields and unify UPnP HTTP handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Unit tests**: the project's first test suite (69 tests) covers DLNA time parsing/formatting, SOAP XML value extraction (position/volume/mute), DIDL-Lite metadata construction (MIME/class detection, XML escaping, subtitle resources, verbatim override), MIME type mapping and SSDP header parsing — making the CI `test` step meaningful
 
 ### 🔧 Changed
+- **Typed `RemoteDevice`**: the `Map<String, Any>` `details` bag is replaced by typed fields — `locationUrl` and `services: List<ServiceInfo>` (`ServiceInfo` is now a top-level class); service URL resolution and TV detection read typed fields instead of unchecked casts
+- **Unified HTTP layer**: device description retrieval and SOAP control requests go through one internal `UpnpHttp` executor (consistent timeouts, User-Agent, connection handling); the description fetch keeps its 3-attempt linear backoff
 - Pure logic extracted from `DlnaMediaController`, `LocalFileServer` and `SsdpDeviceDiscovery` into internal helpers (`UpnpTime`, `SoapXml`, `MetadataBuilder`, `MimeTypes`, `SsdpHeaders`) with no behavior change
 
 ## [1.2.0] - 2026-09-02

--- a/app/src/main/java/com/yinnho/upnpcast/internal/core/CoreManager.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/core/CoreManager.kt
@@ -130,8 +130,7 @@ internal class CoreManager(private val appContext: Context) {
             Log.e(TAG, "Device not found: ${device.id}")
             return false
         }
-        val services = remoteDevice.details["services"] as? List<*>
-        if (services.isNullOrEmpty()) {
+        if (remoteDevice.services.isEmpty()) {
             Log.e(TAG, "Device exposes no services: ${device.id}")
             return false
         }
@@ -313,7 +312,7 @@ internal class CoreManager(private val appContext: Context) {
 
     private fun convertToDevice(remoteDevice: RemoteDevice): Device {
         val manufacturer = remoteDevice.manufacturer.lowercase()
-        val model = (remoteDevice.details["modelName"] as? String ?: "").lowercase()
+        val model = remoteDevice.model.lowercase()
         val isTV = manufacturer.contains("tv") || model.contains("tv") ||
             manufacturer.contains("samsung") || manufacturer.contains("lg") ||
             manufacturer.contains("sony") || manufacturer.contains("xiaomi")

--- a/app/src/main/java/com/yinnho/upnpcast/internal/core/UpnpHttp.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/core/UpnpHttp.kt
@@ -1,0 +1,111 @@
+package com.yinnho.upnpcast.internal.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Shared HTTP execution for UPnP traffic (device description retrieval and
+ * SOAP control requests), so timeouts, headers and connection handling stay
+ * consistent across the library
+ */
+internal object UpnpHttp {
+
+    private const val USER_AGENT = "UPnPCast/1.0"
+
+    /**
+     * GET a resource body; returns null on failure. Retries transient
+     * failures (non-200 or IO error) up to [maxRetries] times with a linear
+     * backoff of [retryDelayMs] * attempt.
+     */
+    suspend fun get(
+        url: String,
+        connectTimeoutMs: Int = 5000,
+        readTimeoutMs: Int = 10000,
+        maxRetries: Int = 1,
+        retryDelayMs: Long = 1000L
+    ): String? = withContext(Dispatchers.IO) {
+        repeat(maxRetries) { attempt ->
+            val attemptNumber = attempt + 1
+            var connection: HttpURLConnection? = null
+            try {
+                connection = URL(url).openConnection() as HttpURLConnection
+                connection.connectTimeout = connectTimeoutMs
+                connection.readTimeout = readTimeoutMs
+                connection.requestMethod = "GET"
+                connection.setRequestProperty("User-Agent", USER_AGENT)
+
+                if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+                    BufferedReader(InputStreamReader(connection.inputStream, "UTF-8")).use { reader ->
+                        return@withContext reader.readText()
+                    }
+                }
+            } catch (e: Exception) {
+                // Fall through to retry
+            } finally {
+                connection?.disconnect()
+            }
+            if (attemptNumber < maxRetries) {
+                delay(retryDelayMs * attemptNumber)
+            }
+        }
+        null
+    }
+
+    /**
+     * POST a SOAP envelope with the given action header; returns the
+     * response body on HTTP 200, null otherwise.
+     */
+    suspend fun postSoap(
+        url: String,
+        soapAction: String,
+        body: String,
+        connectTimeoutMs: Int = 3000,
+        readTimeoutMs: Int = 5000
+    ): String? = withContext(Dispatchers.IO) {
+        var connection: HttpURLConnection? = null
+        try {
+            connection = URL(url).openConnection() as HttpURLConnection
+            connection.requestMethod = "POST"
+            connection.setRequestProperty("Content-Type", "text/xml; charset=utf-8")
+            connection.setRequestProperty("SOAPAction", "\"$soapAction\"")
+            connection.setRequestProperty("User-Agent", USER_AGENT)
+            connection.doOutput = true
+            connection.connectTimeout = connectTimeoutMs
+            connection.readTimeout = readTimeoutMs
+
+            connection.outputStream.use { outputStream ->
+                OutputStreamWriter(outputStream, "UTF-8").use { writer ->
+                    writer.write(soapEnvelope(body))
+                    writer.flush()
+                }
+            }
+
+            if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+                BufferedReader(InputStreamReader(connection.inputStream, "UTF-8")).use { reader ->
+                    reader.readText()
+                }
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    fun soapEnvelope(body: String): String = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+            <s:Body>
+                $body
+            </s:Body>
+        </s:Envelope>
+    """.trimIndent()
+}

--- a/app/src/main/java/com/yinnho/upnpcast/internal/discovery/DeviceDescriptionParser.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/discovery/DeviceDescriptionParser.kt
@@ -1,12 +1,9 @@
 package com.yinnho.upnpcast.internal.discovery
 
 import android.util.Log
+import com.yinnho.upnpcast.internal.core.UpnpHttp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.net.HttpURLConnection
-import java.net.URL
 
 /**
  * UPnP device description parser
@@ -33,14 +30,6 @@ internal class DeviceDescriptionParser {
         val modelName: String,
         val deviceType: String,
         val services: List<ServiceInfo> = emptyList()
-    )
-    
-    data class ServiceInfo(
-        val serviceType: String,
-        val serviceId: String,
-        val controlURL: String,
-        val eventSubURL: String,
-        val descriptorURL: String
     )
     
     /**
@@ -82,40 +71,12 @@ internal class DeviceDescriptionParser {
      * Download XML content
      */
     private suspend fun downloadXmlContent(locationUrl: String): String {
-        val maxRetries = 3
-        
-        for (attempt in 1..maxRetries) {
-            var connection: HttpURLConnection? = null
-            try {
-                val url = URL(locationUrl)
-                connection = url.openConnection() as HttpURLConnection
-                connection.connectTimeout = CONNECT_TIMEOUT
-                connection.readTimeout = READ_TIMEOUT
-                connection.requestMethod = "GET"
-                connection.setRequestProperty("User-Agent", "UPnPCast/1.0")
-                
-                val responseCode = connection.responseCode
-                if (responseCode != HttpURLConnection.HTTP_OK) {
-                    if (attempt == maxRetries) {
-                        return ""
-                    }
-                    kotlinx.coroutines.delay(1000L * attempt)
-                    continue
-                }
-                
-                BufferedReader(InputStreamReader(connection.inputStream, "UTF-8")).use { reader ->
-                    return reader.readText()
-                }
-            } catch (e: Exception) {
-                if (attempt < maxRetries) {
-                    kotlinx.coroutines.delay(1000L * attempt)
-                }
-            } finally {
-                connection?.disconnect()
-            }
-        }
-        
-        return ""
+        return UpnpHttp.get(
+            url = locationUrl,
+            connectTimeoutMs = CONNECT_TIMEOUT,
+            readTimeoutMs = READ_TIMEOUT,
+            maxRetries = 3
+        ) ?: ""
     }
     
     /**
@@ -216,21 +177,15 @@ internal class DeviceDescriptionParser {
         deviceInfo: DeviceInfo?
     ): RemoteDevice {
         val info = deviceInfo ?: DeviceInfo("DLNA Device", "Unknown", "Unknown Model", "Unknown")
-        
+
         return RemoteDevice(
             id = id,
             displayName = info.friendlyName,
             manufacturer = info.manufacturer,
             address = address,
-            details = mapOf(
-                "friendlyName" to info.friendlyName,
-                "manufacturer" to info.manufacturer,
-                "modelName" to info.modelName,
-                "deviceType" to info.deviceType,
-                "locationUrl" to locationUrl,
-                "location" to locationUrl,
-                "services" to info.services
-            )
+            model = info.modelName,
+            locationUrl = locationUrl,
+            services = info.services
         )
     }
 } 

--- a/app/src/main/java/com/yinnho/upnpcast/internal/discovery/RemoteDevice.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/discovery/RemoteDevice.kt
@@ -1,27 +1,39 @@
 package com.yinnho.upnpcast.internal.discovery
 
 /**
+ * A control endpoint of a UPnP service described by the device description
+ */
+data class ServiceInfo(
+    val serviceType: String,
+    val serviceId: String,
+    val controlURL: String,
+    val eventSubURL: String,
+    val descriptorURL: String
+)
+
+/**
  * Remote device information - Simplified version
  */
 data class RemoteDevice(
     val id: String,                    // Unique device identifier (using location URL)
     val displayName: String,           // Display name
-    val address: String,              // Device address
+    val address: String,               // Device address
     val manufacturer: String = "",     // Manufacturer
-    val model: String = "",           // Model
-    val details: Map<String, Any> = emptyMap()  // Device details (location, usn, server, etc.)
+    val model: String = "",            // Model
+    val locationUrl: String = "",      // Device description URL
+    val services: List<ServiceInfo> = emptyList()  // Control endpoints
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is RemoteDevice) return false
         return id == other.id
     }
-    
+
     override fun hashCode(): Int {
         return id.hashCode()
     }
-    
+
     override fun toString(): String {
         return "RemoteDevice(id='$id', name='$displayName', address='$address')"
     }
-} 
+}

--- a/app/src/main/java/com/yinnho/upnpcast/internal/discovery/SsdpDeviceDiscovery.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/discovery/SsdpDeviceDiscovery.kt
@@ -347,13 +347,7 @@ internal class SsdpDeviceDiscovery(
             displayName = "DLNA device",
             manufacturer = "Unknown",
             address = address,
-            details = mapOf(
-                "friendlyName" to "DLNA device",
-                "manufacturer" to "Unknown",
-                "modelName" to "Unknown Model",
-                "deviceType" to "Unknown",
-                "locationUrl" to location
-            )
+            locationUrl = location
         )
     }
 

--- a/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
+++ b/app/src/main/java/com/yinnho/upnpcast/internal/media/DlnaMediaController.kt
@@ -2,15 +2,9 @@ package com.yinnho.upnpcast.internal.media
 
 import android.util.Log
 import kotlinx.coroutines.*
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
-import java.net.HttpURLConnection
-import java.net.URL
-import java.util.Locale
 import com.yinnho.upnpcast.CastOptions
+import com.yinnho.upnpcast.internal.core.UpnpHttp
 import com.yinnho.upnpcast.internal.discovery.RemoteDevice
-import com.yinnho.upnpcast.internal.discovery.DeviceDescriptionParser
 import com.yinnho.upnpcast.internal.util.MetadataBuilder
 import com.yinnho.upnpcast.internal.util.SoapXml
 import com.yinnho.upnpcast.internal.util.UpnpTime
@@ -39,43 +33,31 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
      */
     private fun buildServiceUrl(serviceTypePattern: String, defaultPath: String): String? {
         return try {
-            val services = device.details["services"] as? List<*>
-            if (services != null) {
-                for (service in services) {
-                    if (service is DeviceDescriptionParser.ServiceInfo) {
-                        if (service.serviceType.contains(serviceTypePattern, ignoreCase = true)) {
-                            var controlUrl = service.controlURL
-                            
-                            if (!controlUrl.startsWith("http://") && !controlUrl.startsWith("https://")) {
-                                val location = device.details["location"] as? String
-                                if (location != null) {
-                                    val url = java.net.URL(location)
-                                    val port = url.port.takeIf { it > 0 } ?: 80
-                                    val baseUrl = "http://${device.address}:$port"
-                                    controlUrl = if (controlUrl.startsWith("/")) {
-                                        "$baseUrl$controlUrl"
-                                    } else {
-                                        "$baseUrl/$controlUrl"
-                                    }
-                                }
+            for (service in device.services) {
+                if (service.serviceType.contains(serviceTypePattern, ignoreCase = true)) {
+                    var controlUrl = service.controlURL
+
+                    if (!controlUrl.startsWith("http://") && !controlUrl.startsWith("https://")) {
+                        val location = device.locationUrl
+                        if (location.isNotEmpty()) {
+                            val url = java.net.URL(location)
+                            val port = url.port.takeIf { it > 0 } ?: 80
+                            val baseUrl = "http://${device.address}:$port"
+                            controlUrl = if (controlUrl.startsWith("/")) {
+                                "$baseUrl$controlUrl"
+                            } else {
+                                "$baseUrl/$controlUrl"
                             }
-                            return controlUrl
                         }
                     }
+                    return controlUrl
                 }
             }
-            
-            val location = device.details["location"] as? String
-            val port = if (location != null) {
-                try {
-                    val url = java.net.URL(location)
-                    url.port.takeIf { it > 0 } ?: 80
-                } catch (e: Exception) {
-                    return null
-                }
-            } else {
-                return null
-            }
+
+            val location = device.locationUrl
+            if (location.isEmpty()) return null
+            val url = java.net.URL(location)
+            val port = url.port.takeIf { it > 0 } ?: 80
 
             "http://${device.address}:$port/$defaultPath"
         } catch (e: Exception) {
@@ -295,54 +277,12 @@ internal class DlnaMediaController(private val device: RemoteDevice) {
         soapAction: String,
         body: String,
         returnResponse: Boolean = true
-    ): Any? = withContext(Dispatchers.IO) {
-        var connection: HttpURLConnection? = null
-        try {
-            val soapEnvelope = """
-                <?xml version="1.0" encoding="utf-8"?>
-                <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-                    <s:Body>
-                        $body
-                    </s:Body>
-                </s:Envelope>
-            """.trimIndent()
-            
-            connection = URL(url).openConnection() as HttpURLConnection
-            connection.requestMethod = "POST"
-            connection.setRequestProperty("Content-Type", "text/xml; charset=utf-8")
-            connection.setRequestProperty("SOAPAction", "\"$soapAction\"")
-            connection.setRequestProperty("User-Agent", "UPnPCast/1.0")
-            connection.doOutput = true
-            connection.connectTimeout = 3000
-            connection.readTimeout = 5000
-            
-            connection.outputStream.use { outputStream ->
-                OutputStreamWriter(outputStream, "UTF-8").use { writer ->
-                    writer.write(soapEnvelope)
-                    writer.flush()
-                }
-            }
-            
-            if (connection.responseCode == HttpURLConnection.HTTP_OK) {
-                if (returnResponse) {
-                    connection.inputStream.use { inputStream ->
-                        BufferedReader(InputStreamReader(inputStream, "UTF-8")).use { reader ->
-                            reader.readText()
-                        }
-                    }
-                } else {
-                    true
-                }
-            } else {
-                if (returnResponse) null else false
-            }
-            
-        } catch (e: Exception) {
-            Log.e(tag, "SOAP request failed: $soapAction, ${e.message}")
-            if (returnResponse) null else false
-        } finally {
-            connection?.disconnect()
+    ): Any? {
+        val response = UpnpHttp.postSoap(url, soapAction, body)
+        if (response == null) {
+            Log.e(tag, "SOAP request failed: $soapAction")
         }
+        return if (returnResponse) response else (response != null)
     }
     
     /**


### PR DESCRIPTION
## Summary
- **Typed `RemoteDevice`**: `details: Map<String, Any>` removed; devices now carry `locationUrl` and `services: List<ServiceInfo>` directly (`ServiceInfo` promoted from `DeviceDescriptionParser` to a top-level class). `buildServiceUrl`, cast service checks and TV detection use typed fields instead of unchecked casts
- **Unified `UpnpHttp`**: device description retrieval (GET, 3-attempt linear backoff preserved) and SOAP control requests (POST) share one internal executor with consistent timeouts, User-Agent and connection cleanup
- Completes the v1.3.0 roadmap items started in #8; no public API change

## Test plan
- [x] `./gradlew test lint assembleRelease` passes locally (69/69 tests)
- [ ] CI green
- [ ] Real-device smoke: search → cast → controls still work against an actual renderer