### PR TITLE
Add protocol-level integration tests against a fake DLNA renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### ✨ Added
+- **Protocol-level integration tests**: an in-process fake DLNA renderer (local HTTP + SOAP endpoints) drives the full control flow — device description parsing over HTTP, AVTransport/RenderingControl actions, seek/volume request building, response parsing, `playMediaDirect` sequencing, device-error handling and cache behavior (fetch, cache hit, interpolation only while `PLAYING`); the `DLNACast` facade is covered end to end (neutral defaults before `init`, lifecycle with a WifiManager-less context, fast-failure paths). Suite grows to 92 tests
 - **Unit tests**: the project's first test suite (69 tests) covers DLNA time parsing/formatting, SOAP XML value extraction (position/volume/mute), DIDL-Lite metadata construction (MIME/class detection, XML escaping, subtitle resources, verbatim override), MIME type mapping and SSDP header parsing — making the CI `test` step meaningful
 
 ### 🔧 Changed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,9 +32,13 @@ android {
 
     // Test configuration
     testOptions {
-        unitTests.all {
-            it.enabled = true
-            it.useJUnitPlatform()
+        unitTests {
+            // Library code logs through android.util.Log; unit tests only
+            // need the calls to be no-ops
+            isReturnDefaultValues = true
+            all {
+                it.useJUnitPlatform()
+            }
         }
     }
     

--- a/app/src/test/java/com/yinnho/upnpcast/DLNACastTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/DLNACastTest.kt
@@ -1,0 +1,76 @@
+package com.yinnho.upnpcast
+
+import android.content.Context
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Facade lifecycle: neutral defaults before init, graceful behavior with a
+ * context that has no WifiManager (unit test environment).
+ *
+ * All assertions live in one method because DLNACast is a singleton —
+ * test order inside the method is the only reliable ordering.
+ */
+class DLNACastTest {
+
+    @Test
+    fun facadeLifecycle() = runBlocking {
+        DLNACast.cleanup()
+
+        // Not initialized: neutral defaults, no hangs
+        assertEquals(DLNACast.PlaybackState.IDLE, DLNACast.getPlaybackState())
+        assertTrue(DLNACast.search(100).isEmpty())
+        assertFalse(DLNACast.play())
+        assertFalse(DLNACast.pause())
+        assertFalse(DLNACast.setVolume(50))
+        assertFalse(DLNACast.cast("http://media/movie.mp4", "T"))
+        assertNull(DLNACast.getProgress())
+        assertNull(DLNACast.getVolume())
+        assertFalse(DLNACast.refreshVolumeCache())
+
+        val state = DLNACast.getState()
+        assertFalse(state.isConnected)
+        assertNull(state.currentDevice)
+        assertEquals(DLNACast.PlaybackState.IDLE, state.playbackState)
+
+        val notInitialized = assertThrows(com.yinnho.upnpcast.internal.UPnPException.UnknownError::class.java) {
+            runBlocking {
+                DLNACast.castLocalFile("/no/such/file.mp4", DLNACast.Device("id", "n", "a", false))
+            }
+        }
+        assertTrue(notInitialized.message!!.contains("not initialized"))
+
+        // Initialized with a WifiManager-less context: engine comes up
+        val context = Mockito.mock(Context::class.java)
+        Mockito.`when`(context.applicationContext).thenReturn(context)
+        DLNACast.init(context)
+
+        val initializedState = DLNACast.getState()
+        assertFalse(initializedState.isConnected)
+        assertEquals(DLNACast.PlaybackState.IDLE, initializedState.playbackState)
+
+        // Unknown device fails fast with false, not an exception
+        assertFalse(DLNACast.castToDevice(DLNACast.Device("nope", "n", "a", false), "http://m/v.mp4", "T"))
+        assertFalse(DLNACast.control(DLNACast.MediaAction.PLAY))
+
+        // cleanup restores the neutral state
+        DLNACast.cleanup()
+        assertEquals(DLNACast.PlaybackState.IDLE, DLNACast.getPlaybackState())
+        assertFalse(DLNACast.getState().isConnected)
+    }
+
+    @Test
+    fun scanLocalVideosWithoutPermissionReturnsEmptyList() = runBlocking {
+        // The mocked context's ContentResolver is null; the scanner must
+        // degrade to an empty result rather than crash
+        val context = Mockito.mock(Context::class.java)
+        val videos = DLNACast.scanLocalVideos(context)
+        assertTrue(videos.isEmpty())
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/core/CacheManagerTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/core/CacheManagerTest.kt
@@ -1,0 +1,107 @@
+package com.yinnho.upnpcast.internal.core
+
+import com.yinnho.upnpcast.internal.discovery.RemoteDevice
+import com.yinnho.upnpcast.internal.discovery.ServiceInfo
+import com.yinnho.upnpcast.internal.media.DlnaMediaController
+import com.yinnho.upnpcast.internal.media.FakeDlnaRenderer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CacheManagerTest {
+
+    private lateinit var renderer: FakeDlnaRenderer
+    private lateinit var controller: DlnaMediaController
+    private lateinit var scope: CoroutineScope
+    private lateinit var cacheManager: CacheManager
+
+    @BeforeEach
+    fun setUp() {
+        renderer = FakeDlnaRenderer().startServer()
+        controller = DlnaMediaController(deviceFor(renderer))
+        scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        cacheManager = CacheManager(scope)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        cacheManager.clearAll()
+        scope.cancel()
+        controller.release()
+        renderer.stop()
+    }
+
+    private fun deviceFor(renderer: FakeDlnaRenderer) = RemoteDevice(
+        id = renderer.descriptionUrl,
+        displayName = "Test Renderer",
+        address = "127.0.0.1",
+        locationUrl = renderer.descriptionUrl,
+        services = listOf(
+            ServiceInfo("urn:schemas-upnp-org:service:AVTransport:1", "a", "/control/AVTransport", "/e", "/s"),
+            ServiceInfo("urn:schemas-upnp-org:service:RenderingControl:1", "r", "/control/RenderingControl", "/e", "/s")
+        )
+    )
+
+    @Test
+    fun queriesWithoutControllerReturnNull() = runBlocking {
+        assertNull(cacheManager.getProgress(null))
+        assertNull(cacheManager.getVolume(null))
+    }
+
+    @Test
+    fun progressIsFetchedAndThenServedFromCache() = runBlocking {
+        val first = cacheManager.getProgress(controller)
+        assertEquals(Pair(10000L, 600000L), first)
+
+        val positionCallsAfterFirst = renderer.callsFor("GetPositionInfo").size
+        val second = cacheManager.getProgress(controller)
+        assertNotNull(second)
+        assertEquals(positionCallsAfterFirst, renderer.callsFor("GetPositionInfo").size)
+    }
+
+    @Test
+    fun progressInterpolatesOnlyWhilePlaying() = runBlocking {
+        assertTrue(cacheManager.refreshProgressCache(controller))
+        assertEquals("PLAYING", cacheManager.cachedTransportState)
+
+        // Second read inside the cache window advances the position
+        val interpolated = cacheManager.getProgress(controller)!!
+        assertTrue(interpolated.first >= 10000L)
+        assertEquals(600000L, interpolated.second)
+
+        // A paused device must not advance
+        renderer.transportState = "PAUSED_PLAYBACK"
+        assertTrue(cacheManager.refreshProgressCache(controller))
+        val paused = cacheManager.getProgress(controller)!!
+        assertTrue(paused.first < 11000L)
+    }
+
+    @Test
+    fun volumeIsCachedWithMuteState() = runBlocking {
+        assertEquals(Pair(30, false), cacheManager.getVolume(controller))
+
+        val volumeCallsAfterFirst = renderer.callsFor("GetVolume").size
+        assertEquals(Pair(30, false), cacheManager.getVolume(controller))
+        assertEquals(volumeCallsAfterFirst, renderer.callsFor("GetVolume").size)
+    }
+
+    @Test
+    fun clearAllResetsCachedState() = runBlocking {
+        cacheManager.refreshProgressCache(controller)
+        cacheManager.refreshVolumeCache(controller)
+
+        cacheManager.clearAll()
+
+        assertNull(cacheManager.cachedTransportState)
+        assertEquals(-1, cacheManager.getVolumeState().first)
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/discovery/DeviceDescriptionParserTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/discovery/DeviceDescriptionParserTest.kt
@@ -1,0 +1,87 @@
+package com.yinnho.upnpcast.internal.discovery
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Parses a real device description document fetched over HTTP from an
+ * in-process fake renderer
+ */
+class DeviceDescriptionParserTest {
+
+    private lateinit var renderer: com.yinnho.upnpcast.internal.media.FakeDlnaRenderer
+    private val parser = DeviceDescriptionParser()
+
+    @BeforeEach
+    fun setUp() {
+        renderer = com.yinnho.upnpcast.internal.media.FakeDlnaRenderer().startServer()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        renderer.stop()
+    }
+
+    @Test
+    fun parsesDescriptionOverHttp() = runBlocking {
+        val info = parser.parseDeviceDescription(renderer.descriptionUrl)
+
+        assertEquals("Test Renderer", info?.friendlyName)
+        assertEquals("UnitTest Corp", info?.manufacturer)
+        assertEquals("TestModel 1000", info?.modelName)
+        assertEquals(2, info?.services?.size)
+
+        val avTransport = info?.services?.first { it.serviceType.contains("AVTransport") }
+        assertEquals("/control/AVTransport", avTransport?.controlURL)
+    }
+
+    @Test
+    fun createEnhancedDeviceMapsTypedFields() {
+        val device = parser.createEnhancedDevice(
+            id = renderer.descriptionUrl,
+            address = "127.0.0.1",
+            locationUrl = renderer.descriptionUrl,
+            deviceInfo = DeviceDescriptionParser.DeviceInfo(
+                friendlyName = "F",
+                manufacturer = "M",
+                modelName = "MM",
+                deviceType = "T",
+                services = listOf(
+                    ServiceInfo("urn:schemas-upnp-org:service:AVTransport:1", "id", "/c", "/e", "/s")
+                )
+            )
+        )
+
+        assertEquals("F", device.displayName)
+        assertEquals("M", device.manufacturer)
+        assertEquals("MM", device.model)
+        assertEquals(renderer.descriptionUrl, device.locationUrl)
+        assertEquals(1, device.services.size)
+        assertEquals("/c", device.services.single().controlURL)
+    }
+
+    @Test
+    fun createEnhancedDeviceFallsBackToDefaults() {
+        val device = parser.createEnhancedDevice(
+            id = "id",
+            address = "1.2.3.4",
+            locationUrl = "http://1.2.3.4/desc",
+            deviceInfo = null
+        )
+
+        assertEquals("DLNA Device", device.displayName)
+        assertEquals("Unknown", device.manufacturer)
+        assertTrue(device.services.isEmpty())
+    }
+
+    @Test
+    fun unreachableDescriptionReturnsNull() = runBlocking {
+        // 404 path retries 3 times before giving up (~3s of backoff)
+        assertNull(parser.parseDeviceDescription("${renderer.baseUrl}/nope"))
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/media/DlnaMediaControllerTest.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/media/DlnaMediaControllerTest.kt
@@ -1,0 +1,144 @@
+package com.yinnho.upnpcast.internal.media
+
+import com.yinnho.upnpcast.internal.discovery.RemoteDevice
+import com.yinnho.upnpcast.internal.discovery.ServiceInfo
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the SOAP control flow against an in-process fake renderer —
+ * covers request building, URL resolution and response parsing end to end
+ */
+class DlnaMediaControllerTest {
+
+    private lateinit var renderer: FakeDlnaRenderer
+    private lateinit var controller: DlnaMediaController
+
+    @BeforeEach
+    fun setUp() {
+        renderer = FakeDlnaRenderer().startServer()
+        controller = DlnaMediaController(deviceFor(renderer))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        controller.release()
+        renderer.stop()
+    }
+
+    private fun deviceFor(renderer: FakeDlnaRenderer): RemoteDevice = RemoteDevice(
+        id = renderer.descriptionUrl,
+        displayName = "Test Renderer",
+        address = "127.0.0.1",
+        manufacturer = "UnitTest Corp",
+        model = "TestModel 1000",
+        locationUrl = renderer.descriptionUrl,
+        services = listOf(
+            ServiceInfo(
+                serviceType = "urn:schemas-upnp-org:service:AVTransport:1",
+                serviceId = "AVTransport",
+                controlURL = "/control/AVTransport",
+                eventSubURL = "/event/AVTransport",
+                descriptorURL = "/scpd/AVTransport.xml"
+            ),
+            ServiceInfo(
+                serviceType = "urn:schemas-upnp-org:service:RenderingControl:1",
+                serviceId = "RenderingControl",
+                controlURL = "/control/RenderingControl",
+                eventSubURL = "/event/RenderingControl",
+                descriptorURL = "/scpd/RenderingControl.xml"
+            )
+        )
+    )
+
+    @Test
+    fun getTransportInfoQueriesRenderer() = runBlocking {
+        assertEquals("PLAYING", controller.getTransportInfo())
+        assertEquals(1, renderer.callsFor("GetTransportInfo").size)
+    }
+
+    @Test
+    fun getPositionInfoParsesRelTimeAndDuration() = runBlocking {
+        assertEquals(Pair(10000L, 600000L), controller.getPositionInfo())
+    }
+
+    @Test
+    fun volumeAndMuteAreParsed() = runBlocking {
+        assertEquals(30, controller.getVolumeAsync())
+        assertEquals(false, controller.getMuteAsync())
+    }
+
+    @Test
+    fun playSendsPlayAction() = runBlocking {
+        assertTrue(controller.control("play"))
+        assertEquals(1, renderer.callsFor("Play").size)
+        assertTrue(renderer.callsFor("Play").single().body.contains("<Speed>1</Speed>"))
+    }
+
+    @Test
+    fun seekFormatsTargetAsColonTime() = runBlocking {
+        assertTrue(controller.control("seek", 90000L))
+        val body = renderer.callsFor("Seek").single().body
+        assertTrue(body.contains("<Unit>REL_TIME</Unit>"))
+        assertTrue(body.contains("<Target>00:01:30</Target>"))
+    }
+
+    @Test
+    fun volumeIsCoercedIntoRange() = runBlocking {
+        assertTrue(controller.control("volume", 150))
+        assertTrue(renderer.callsFor("SetVolume").single().body.contains("<DesiredVolume>100</DesiredVolume>"))
+    }
+
+    @Test
+    fun muteMapsBooleanState() = runBlocking {
+        assertTrue(controller.control("mute", true))
+        assertTrue(renderer.callsFor("SetMute").single().body.contains("<DesiredMute>1</DesiredMute>"))
+    }
+
+    @Test
+    fun playMediaDirectSetsUriThenPlays() = runBlocking {
+        assertTrue(controller.playMediaDirect("http://media.example.com/movie.mp4", "Movie"))
+
+        val actions = renderer.soapCalls.map { it.action }
+        assertEquals(listOf("SetAVTransportURI", "Play"), actions)
+
+        val setUri = renderer.callsFor("SetAVTransportURI").single().body
+        assertTrue(setUri.contains("<CurrentURI>http://media.example.com/movie.mp4</CurrentURI>"))
+        assertTrue(setUri.contains("<dc:title>Movie</dc:title>"))
+    }
+
+    @Test
+    fun playMediaDirectForwardsPositionAsSeek() = runBlocking {
+        assertTrue(controller.playMediaDirect("http://m/v.mp4", "T", positionMs = 30000))
+        assertEquals(listOf("SetAVTransportURI", "Play", "Seek"), renderer.soapCalls.map { it.action })
+        assertTrue(renderer.callsFor("Seek").single().body.contains("<Target>00:00:30</Target>"))
+    }
+
+    @Test
+    fun deviceErrorsSurfaceAsFailure() = runBlocking {
+        renderer.failControlRequests = true
+
+        assertFalse(controller.control("play"))
+        assertNull(controller.getTransportInfo())
+        assertNull(controller.getVolumeAsync())
+    }
+
+    @Test
+    fun unknownActionFailsWithoutHttpRequest() = runBlocking {
+        assertFalse(controller.control("dance"))
+        assertTrue(renderer.soapCalls.isEmpty())
+    }
+
+    @Test
+    fun releasedControllerRejectsRequests() = runBlocking {
+        controller.release()
+        assertFalse(controller.control("play"))
+        assertNull(controller.getTransportInfo())
+    }
+}

--- a/app/src/test/java/com/yinnho/upnpcast/internal/media/FakeDlnaRenderer.kt
+++ b/app/src/test/java/com/yinnho/upnpcast/internal/media/FakeDlnaRenderer.kt
@@ -1,0 +1,105 @@
+package com.yinnho.upnpcast.internal.media
+
+import fi.iki.elonen.NanoHTTPD
+
+/**
+ * Minimal in-process DLNA renderer for unit tests: serves a device
+ * description document and AVTransport / RenderingControl SOAP endpoints,
+ * recording every control call.
+ */
+class FakeDlnaRenderer : NanoHTTPD("127.0.0.1", 0) {
+
+    data class SoapCall(val action: String, val body: String)
+
+    val soapCalls = mutableListOf<SoapCall>()
+
+    var transportState = "PLAYING"
+    var relTime = "00:00:10"
+    var trackDuration = "00:10:00"
+    var volume = "30"
+    var mute = "0"
+    var failControlRequests = false
+
+    val baseUrl: String get() = "http://127.0.0.1:$listeningPort"
+    val descriptionUrl: String get() = "$baseUrl/dev/desc"
+
+    val descriptionXml: String
+        get() = """
+            <?xml version="1.0"?>
+            <root xmlns="urn:schemas-upnp-org:device-1-0">
+                <device>
+                    <deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>
+                    <friendlyName>Test Renderer</friendlyName>
+                    <manufacturer>UnitTest Corp</manufacturer>
+                    <modelName>TestModel 1000</modelName>
+                    <serviceList>
+                        <service>
+                            <serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>
+                            <serviceId>AVTransport</serviceId>
+                            <controlURL>/control/AVTransport</controlURL>
+                            <eventSubURL>/event/AVTransport</eventSubURL>
+                            <SCPDURL>/scpd/AVTransport.xml</SCPDURL>
+                        </service>
+                        <service>
+                            <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
+                            <serviceId>RenderingControl</serviceId>
+                            <controlURL>/control/RenderingControl</controlURL>
+                            <eventSubURL>/event/RenderingControl</eventSubURL>
+                            <SCPDURL>/scpd/RenderingControl.xml</SCPDURL>
+                        </service>
+                    </serviceList>
+                </device>
+            </root>
+        """.trimIndent()
+
+    fun startServer(): FakeDlnaRenderer {
+        start(SOCKET_READ_TIMEOUT, false)
+        return this
+    }
+
+    fun controlUrls(): Pair<String, String> = "/control/AVTransport" to "/control/RenderingControl"
+
+    override fun serve(session: IHTTPSession): Response {
+        return when (session.uri) {
+            "/dev/desc" -> newFixedLengthResponse(Response.Status.OK, "text/xml", descriptionXml)
+            "/control/AVTransport", "/control/RenderingControl" -> serveControl(session)
+            else -> newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "not found")
+        }
+    }
+
+    private fun serveControl(session: IHTTPSession): Response {
+        if (failControlRequests) {
+            return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, "text/xml", "boom")
+        }
+
+        val body = readBody(session)
+        val action = ACTION_REGEX.find(body)?.groupValues?.get(1) ?: "Unknown"
+        soapCalls.add(SoapCall(action, body))
+
+        val inner = when (action) {
+            "GetTransportInfo" -> "<CurrentTransportState>$transportState</CurrentTransportState>"
+            "GetPositionInfo" -> "<RelTime>$relTime</RelTime><TrackDuration>$trackDuration</TrackDuration>"
+            "GetVolume" -> "<CurrentVolume>$volume</CurrentVolume>"
+            "GetMute" -> "<CurrentMute>$mute</CurrentMute>"
+            else -> ""
+        }
+        val envelope = """<?xml version="1.0"?><s:Envelope><s:Body><u:${action}Response>$inner</u:${action}Response></s:Body></s:Envelope>"""
+        return newFixedLengthResponse(Response.Status.OK, "text/xml", envelope)
+    }
+
+    private fun readBody(session: IHTTPSession): String {
+        return try {
+            val files = HashMap<String, String>()
+            session.parseBody(files)
+            files["postData"] ?: ""
+        } catch (e: Exception) {
+            ""
+        }
+    }
+
+    fun callsFor(action: String): List<SoapCall> = soapCalls.filter { it.action == action }
+
+    companion object {
+        private val ACTION_REGEX = "<u:([A-Za-z]+)".toRegex()
+    }
+}


### PR DESCRIPTION
## Summary
- New `FakeDlnaRenderer` test helper: in-process NanoHTTPD server serving a device description document and SOAP control endpoints, recording every call — real HTTP, real SOAP envelopes, no mocks of the code under test
- `DlnaMediaControllerTest` (12 tests): transport/position/volume/mute queries, play/pause/seek/volume/mute request building (seek formats `00:01:30`, volume coerced to 0–100), `playMediaDirect` SetAVTransportURI→Play(→Seek) sequencing and metadata, device-error handling, released-controller behavior
- `DeviceDescriptionParserTest` (4): parses the description over real HTTP, typed field mapping, fallback defaults, unreachable-URL null
- `CacheManagerTest` (5): cache fetch + hit (no duplicate requests), interpolation only while `PLAYING`, volume cache, clearAll
- `DLNACastTest` (2): facade lifecycle — neutral defaults before `init()` (no hangs), engine comes up with a WifiManager-less context, unknown-device/control fast failures, `castLocalFile` throws `UnknownError` when not initialized
- Unit tests stub `android.util.Log` via `isReturnDefaultValues = true`; suite: 69 → 92 tests

Compensates for the missing real-device smoke pass on the protocol level (SOAP/discovery-adjacent flows); physical-device checks (subtitle rendering, local-file seek on a TV, remote pause) remain on the checklist.

## Test plan
- [x] `./gradlew test lint assembleRelease` — 92/92 green locally
- [ ] CI green