### PR TITLE
Release v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
         name: release-artifacts
         path: |
           app/build/outputs/aar/*
-          ~/.m2/repository/com/github/yinnho/UPnPCast/1.2.0/* 
+          ~/.m2/repository/com/github/yinnho/UPnPCast/1.3.0/* 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the UPnPCast library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-09-02
 
 ### ✨ Added
 - **Protocol-level integration tests**: an in-process fake DLNA renderer (local HTTP + SOAP endpoints) drives the full control flow — device description parsing over HTTP, AVTransport/RenderingControl actions, seek/volume request building, response parsing, `playMediaDirect` sequencing, device-error handling and cache behavior (fetch, cache hit, interpolation only while `PLAYING`); the `DLNACast` facade is covered end to end (neutral defaults before `init`, lifecycle with a WifiManager-less context, fast-failure paths). Suite grows to 92 tests

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         minSdk = 24
         
         // Version information setting
-        version = "1.2.0"
+        version = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         
@@ -132,7 +132,7 @@ afterEvaluate {
                 
                 groupId = "com.yinnho.upnpcast"
                 artifactId = "upnpcast"
-                version = "1.2.0"
+                version = "1.3.0"
                 
                 pom {
                     name.set("UPnPCast")


### PR DESCRIPTION
## Summary
- Version bump 1.2.0 → 1.3.0 (`app/build.gradle.kts`, publishing block, CI artifact path)
- CHANGELOG `[Unreleased]` → `[1.3.0] - 2026-09-02`: test suite (69 unit + 23 fake-renderer integration tests), typed `RemoteDevice`, unified `UpnpHttp` layer

## Test plan
- [x] `./gradlew test lint assembleRelease` passes locally (both variants)
- [ ] CI green